### PR TITLE
Add ICS calendar management dialog

### DIFF
--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { Stack } from '@mui/material';
+import { IconButton, Stack } from '@mui/material';
+import SettingsIcon from '@mui/icons-material/Settings';
 
 import { DashboardViewState } from '@/types/DashboardViewState';
 import { IWeather } from '@/types/IWeather';
@@ -12,6 +13,7 @@ import { EventList } from '@/widgets/EventList';
 import { EventTimeline } from '@/widgets/EventTimeline';
 import { SoundAlert } from '@/widgets/SoundAlert';
 import { Weather } from '@/widgets/Weather';
+import { SettingsDialog } from '@/widgets/Settings';
 
 interface HomeViewProps {
   dashboardViewState: DashboardViewState;
@@ -47,6 +49,7 @@ export function HomeView({
   weatherError,
 }: HomeViewProps) {
   const [now, setNow] = useState(new Date());
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const {
     severity,
     message,
@@ -66,6 +69,14 @@ export function HomeView({
 
   return (
     <Stack p={2} spacing={6}>
+      <IconButton
+        aria-label="settings"
+        onClick={() => setSettingsOpen(true)}
+        sx={{ position: 'fixed', top: 16, right: 16 }}
+      >
+        <SettingsIcon />
+      </IconButton>
+      <SettingsDialog open={settingsOpen} onClose={() => setSettingsOpen(false)} />
       <EventTimeline events={events} currentTime={now} pastWindowHours={3} futureWindowHours={6} />
 
       <Stack direction="row" justifyContent="space-around">

--- a/src/widgets/ICSCalendarManager/index.tsx
+++ b/src/widgets/ICSCalendarManager/index.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useState } from 'react';
+
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import { Circle as StatusIcon } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  IconButton,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemSecondaryAction,
+  ListItemText,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import { getStoredFilters, setStoredFilters } from '@/utils/localStorageUtils';
+
+// Shape of a stored calendar configuration
+export interface IcsCalendarConfig {
+  url: string;
+  id: string;
+  name: string;
+  color: string; // hex code without leading '#'
+}
+
+const STORAGE_KEY = 'ics-calendars';
+
+function loadCalendars(): IcsCalendarConfig[] {
+  try {
+    return getStoredFilters<IcsCalendarConfig[]>(STORAGE_KEY) ?? [];
+  } catch (err) {
+    console.error('Failed to load calendars', err);
+    return [];
+  }
+}
+
+function persistCalendars(calendars: IcsCalendarConfig[]) {
+  try {
+    setStoredFilters(STORAGE_KEY, calendars);
+  } catch (err) {
+    console.error('Failed to save calendars', err);
+  }
+}
+
+// Form state used for adding or editing a calendar
+interface CalendarFormState {
+  url: string;
+  id: string;
+  name: string;
+  color: string;
+}
+
+export function ICSCalendarManager() {
+  const [calendars, setCalendars] = useState<IcsCalendarConfig[]>([]);
+  const [form, setForm] = useState<CalendarFormState>({ url: '', id: '', name: '', color: '' });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    setCalendars(loadCalendars());
+  }, []);
+
+  const handleChange =
+    (field: keyof CalendarFormState) => (event: React.ChangeEvent<HTMLInputElement>) => {
+      setForm({ ...form, [field]: event.target.value });
+    };
+
+  function resetForm() {
+    setForm({ url: '', id: '', name: '', color: '' });
+    setErrors({});
+    setEditingIndex(null);
+  }
+
+  function validate(current: CalendarFormState): boolean {
+    const newErrors: Record<string, string> = {};
+
+    if (!current.url.trim()) {
+      newErrors.url = 'URL is required';
+    } else {
+      try {
+        new URL(current.url);
+      } catch {
+        newErrors.url = 'Invalid URL';
+      }
+    }
+
+    if (!current.id.trim()) newErrors.id = 'ID is required';
+    if (!current.name.trim()) newErrors.name = 'Name is required';
+
+    if (!/^#?[0-9a-fA-F]{6}$/.test(current.color.trim())) {
+      newErrors.color = 'Invalid hex color';
+    }
+
+    // duplicates
+    const others = calendars.filter((_, i) => i !== editingIndex);
+    if (others.some(c => c.id === current.id.trim())) newErrors.id = 'Duplicate ID';
+    if (others.some(c => c.url === current.url.trim())) newErrors.url = 'Duplicate URL';
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }
+
+  function handleSubmit() {
+    if (!validate(form)) return;
+
+    const normalized: IcsCalendarConfig = {
+      url: form.url.trim(),
+      id: form.id.trim(),
+      name: form.name.trim(),
+      color: form.color.replace(/^#/, '').toUpperCase(),
+    };
+
+    let updated: IcsCalendarConfig[];
+    if (editingIndex != null) {
+      updated = calendars.map((c, i) => (i === editingIndex ? normalized : c));
+    } else {
+      updated = [...calendars, normalized];
+    }
+
+    setCalendars(updated);
+    persistCalendars(updated);
+    resetForm();
+  }
+
+  function handleEdit(index: number) {
+    const cal = calendars[index];
+    setForm({
+      url: cal.url,
+      id: cal.id,
+      name: cal.name,
+      color: cal.color,
+    });
+    setEditingIndex(index);
+  }
+
+  function handleDelete(index: number) {
+    const updated = calendars.filter((_, i) => i !== index);
+    setCalendars(updated);
+    persistCalendars(updated);
+    if (editingIndex === index) resetForm();
+  }
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        ICS Calendars
+      </Typography>
+
+      <List dense disablePadding>
+        {calendars.map((cal, idx) => (
+          <ListItem key={cal.id} sx={{ pl: 0 }}>
+            <ListItemIcon>
+              <StatusIcon sx={{ color: `#${cal.color}` }} />
+            </ListItemIcon>
+            <ListItemText primary={cal.name} secondary={cal.url} />
+            <ListItemSecondaryAction>
+              <IconButton edge="end" aria-label="edit" onClick={() => handleEdit(idx)}>
+                <EditIcon fontSize="small" />
+              </IconButton>
+              <IconButton edge="end" aria-label="delete" onClick={() => handleDelete(idx)}>
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </ListItemSecondaryAction>
+          </ListItem>
+        ))}
+        {calendars.length === 0 && (
+          <ListItem sx={{ pl: 0 }}>
+            <ListItemText primary="No calendars" />
+          </ListItem>
+        )}
+      </List>
+
+      <Box component="form" sx={{ mt: 2 }} noValidate autoComplete="off">
+        <Stack spacing={2}>
+          <TextField
+            label="ICS URL"
+            value={form.url}
+            onChange={handleChange('url')}
+            error={Boolean(errors.url)}
+            helperText={errors.url}
+            fullWidth
+          />
+          <TextField
+            label="Calendar ID"
+            value={form.id}
+            onChange={handleChange('id')}
+            error={Boolean(errors.id)}
+            helperText={errors.id}
+            fullWidth
+          />
+          <TextField
+            label="Calendar Name"
+            value={form.name}
+            onChange={handleChange('name')}
+            error={Boolean(errors.name)}
+            helperText={errors.name}
+            fullWidth
+          />
+          <TextField
+            label="Color"
+            value={form.color}
+            onChange={handleChange('color')}
+            error={Boolean(errors.color)}
+            helperText={errors.color || 'Hex color, e.g. #FFA836'}
+            fullWidth
+          />
+          <Stack direction="row" justifyContent="flex-end" spacing={2}>
+            <Button onClick={resetForm}>Clear</Button>
+            <Button variant="contained" onClick={handleSubmit}>
+              {editingIndex != null ? 'Update' : 'Add'}
+            </Button>
+          </Stack>
+        </Stack>
+      </Box>
+    </Box>
+  );
+}
+
+export default ICSCalendarManager;

--- a/src/widgets/Settings/index.tsx
+++ b/src/widgets/Settings/index.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+import SettingsIcon from '@mui/icons-material/Settings';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Tab,
+  Tabs,
+  Box,
+  Typography,
+} from '@mui/material';
+
+import ICSCalendarManager from '@/widgets/ICSCalendarManager';
+
+interface SettingsDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
+  const [tab, setTab] = useState(0);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Settings</DialogTitle>
+      <DialogContent>
+        <Tabs value={tab} onChange={(_, v) => setTab(v)} aria-label="settings tabs">
+          <Tab label="Calendars" />
+          <Tab label="Other" />
+        </Tabs>
+        <Box hidden={tab !== 0} pt={2}>
+          <ICSCalendarManager />
+        </Box>
+        <Box hidden={tab !== 1} pt={2}>
+          <Typography variant="body2">More settings coming soon…</Typography>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface SettingsButtonProps {
+  onClick: () => void;
+}
+
+export function SettingsButton({ onClick }: SettingsButtonProps) {
+  return (
+    <IconButton
+      aria-label="settings"
+      onClick={onClick}
+      sx={{ position: 'fixed', top: 16, right: 16 }}
+    >
+      <SettingsIcon />
+    </IconButton>
+  );
+}
+
+export default SettingsDialog;


### PR DESCRIPTION
## Summary
- create `ICSCalendarManager` component for adding, editing and removing ICS calendar configs stored in localStorage
- add `SettingsDialog` with gear button for opening settings
- integrate settings dialog into `HomeView`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_685ddb2700a0832981a789cf8e85959c