### PR TITLE
Refactor TodoList widget

### DIFF
--- a/src/widgets/TodoList/boardStorage.ts
+++ b/src/widgets/TodoList/boardStorage.ts
@@ -1,0 +1,32 @@
+import { getStoredFilters, setStoredFilters } from '@/utils/localStorageUtils';
+import type { BoardState, Column } from './types';
+
+export const STORAGE_KEY = 'todo-board';
+export const LAST_POPULATE_KEY = 'todo-last-populate';
+
+export const DEFAULT_COLUMNS: Column[] = [
+  { id: 'todo', title: 'Todo', color: '#1976d2' },
+  { id: 'completed', title: 'Completed', color: '#2e7d32' },
+];
+
+export function loadBoard(): BoardState {
+  try {
+    return (
+      getStoredFilters<BoardState>(STORAGE_KEY) || {
+        columns: DEFAULT_COLUMNS,
+        items: [],
+      }
+    );
+  } catch {
+    return { columns: DEFAULT_COLUMNS, items: [] };
+  }
+}
+
+export function saveBoard(board: BoardState): void {
+  try {
+    setStoredFilters(STORAGE_KEY, board);
+  } catch {
+    // Failing to persist should not break UI but we log for debugging
+    console.error('Could not save todo board');
+  }
+}

--- a/src/widgets/TodoList/components/AddItemForm.tsx
+++ b/src/widgets/TodoList/components/AddItemForm.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+
+import AddIcon from '@mui/icons-material/Add';
+import { Button, Stack, TextField } from '@mui/material';
+
+interface AddItemFormProps {
+  onAdd: (title: string, description: string, tags: string[]) => void;
+}
+
+export function AddItemForm({ onAdd }: AddItemFormProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState('');
+
+  const handleAdd = () => {
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) return;
+
+    onAdd(
+      trimmedTitle,
+      description.trim(),
+      tags
+        .split(',')
+        .map(t => t.trim())
+        .filter(Boolean),
+    );
+
+    setTitle('');
+    setDescription('');
+    setTags('');
+  };
+
+  return (
+    <Stack mt={2} spacing={1} component="form" onSubmit={e => e.preventDefault()}>
+      <TextField label="Title" value={title} onChange={e => setTitle(e.target.value)} />
+      <TextField label="Description" value={description} onChange={e => setDescription(e.target.value)} />
+      <TextField
+        label="Tags (comma separated)"
+        value={tags}
+        onChange={e => setTags(e.target.value)}
+      />
+      <Button variant="contained" onClick={handleAdd} startIcon={<AddIcon />}>
+        Add Item
+      </Button>
+    </Stack>
+  );
+}

--- a/src/widgets/TodoList/components/TodoColumn.tsx
+++ b/src/widgets/TodoList/components/TodoColumn.tsx
@@ -1,0 +1,66 @@
+import { alpha, Box, IconButton, Stack, Typography } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+
+import type { Column, TodoItem } from '../types';
+import { TodoItemCard } from './TodoItemCard';
+
+interface TodoColumnProps {
+  column: Column;
+  items: TodoItem[];
+  onRenameColumn: (id: string) => void;
+  onDeleteColumn: (id: string) => void;
+  onEditItem: (id: string) => void;
+  onDeleteItem: (id: string) => void;
+  onCompleteItem: (id: string) => void;
+  onDragStart: (e: React.DragEvent<HTMLDivElement>, id: string) => void;
+  onDragOverItem: (e: React.DragEvent<HTMLDivElement>, id: string) => void;
+  onDrop: (e: React.DragEvent<HTMLDivElement>, columnId: string) => void;
+}
+
+export function TodoColumn({
+  column,
+  items,
+  onRenameColumn,
+  onDeleteColumn,
+  onEditItem,
+  onDeleteItem,
+  onCompleteItem,
+  onDragStart,
+  onDragOverItem,
+  onDrop,
+}: TodoColumnProps) {
+  return (
+    <Box
+      onDragOver={e => e.preventDefault()}
+      onDrop={e => onDrop(e, column.id)}
+      sx={{ width: 250, p: 1, bgcolor: alpha(column.color, 0.1), borderRadius: 1 }}
+    >
+      <Stack direction="row" alignItems="center" justifyContent="space-between" mb={1}>
+        <Typography variant="h6" sx={{ color: column.color }}>
+          {column.title}
+        </Typography>
+        <Stack direction="row" spacing={0}>
+          <IconButton size="small" onClick={() => onRenameColumn(column.id)}>
+            <EditIcon fontSize="inherit" />
+          </IconButton>
+          <IconButton size="small" onClick={() => onDeleteColumn(column.id)}>
+            <DeleteIcon fontSize="inherit" />
+          </IconButton>
+        </Stack>
+      </Stack>
+      {items.map(item => (
+        <TodoItemCard
+          key={item.id}
+          item={item}
+          column={column}
+          onEdit={onEditItem}
+          onDelete={onDeleteItem}
+          onComplete={onCompleteItem}
+          onDragStart={onDragStart}
+          onDragOver={onDragOverItem}
+        />
+      ))}
+    </Box>
+  );
+}

--- a/src/widgets/TodoList/components/TodoItemCard.tsx
+++ b/src/widgets/TodoList/components/TodoItemCard.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+
+import CheckIcon from '@mui/icons-material/Check';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import InfoIcon from '@mui/icons-material/Info';
+import { Box, Chip, Dialog, DialogContent, IconButton, Stack, Tooltip, Typography } from '@mui/material';
+
+import type { Column, TodoItem } from '../types';
+
+interface TodoItemCardProps {
+  item: TodoItem;
+  column: Column;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+  onComplete: (id: string) => void;
+  onDragStart: (e: React.DragEvent<HTMLDivElement>, id: string) => void;
+  onDragOver: (e: React.DragEvent<HTMLDivElement>, id: string) => void;
+}
+
+export function TodoItemCard({ item, column, onEdit, onDelete, onComplete, onDragStart, onDragOver }: TodoItemCardProps) {
+  const [showDescription, setShowDescription] = useState(false);
+
+  return (
+    <Box
+      data-todo-id={item.id}
+      draggable
+      onDragStart={e => onDragStart(e, item.id)}
+      onDragOver={e => onDragOver(e, item.id)}
+      sx={{ p: 1, border: '1px solid', borderColor: column.color, borderRadius: 1, mb: 1, position: 'relative' }}
+    >
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Typography variant="body1">{item.title}</Typography>
+          {item.description && (
+            <Tooltip title="Show description">
+              <IconButton size="small" onClick={() => setShowDescription(true)}>
+                <InfoIcon fontSize="inherit" />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Stack>
+        <Stack direction="row" spacing={1} sx={{ visibility: 'hidden' }} className="todo-actions">
+          <IconButton size="small" onClick={() => onEdit(item.id)}>
+            <EditIcon fontSize="inherit" />
+          </IconButton>
+          <IconButton size="small" onClick={() => onComplete(item.id)}>
+            <CheckIcon fontSize="inherit" />
+          </IconButton>
+          <IconButton size="small" onClick={() => onDelete(item.id)}>
+            <DeleteIcon fontSize="inherit" />
+          </IconButton>
+        </Stack>
+      </Stack>
+      <Stack direction="row" spacing={1} mt={0.5} flexWrap="wrap">
+        {item.tags.map(tag => (
+          <Chip key={tag} label={tag} size="small" />
+        ))}
+      </Stack>
+      <Dialog open={showDescription} onClose={() => setShowDescription(false)}>
+        <DialogContent>
+          <Typography>{item.description}</Typography>
+        </DialogContent>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/widgets/TodoList/index.tsx
+++ b/src/widgets/TodoList/index.tsx
@@ -1,83 +1,26 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import AddIcon from '@mui/icons-material/Add';
-import CheckIcon from '@mui/icons-material/Check';
-import DeleteIcon from '@mui/icons-material/Delete';
-import EditIcon from '@mui/icons-material/Edit';
 import ListIcon from '@mui/icons-material/List';
 import ViewColumnIcon from '@mui/icons-material/ViewColumn';
-import {
-  alpha,
-  Box,
-  Button,
-  Chip,
-  IconButton,
-  Stack,
-  TextField,
-  Tooltip,
-  Typography,
-} from '@mui/material';
+import { Box, Button, Stack, TextField, Typography } from '@mui/material';
 
 import type { IEvent } from '@/types/IEvent';
 import { filterFullDayEventsForTodayInUTC } from '@/utils/eventUtils';
 import { getStoredFilters, setStoredFilters } from '@/utils/localStorageUtils';
 
-interface Column {
-  id: string;
-  title: string;
-  color: string;
-}
-
-interface TodoItem {
-  id: string;
-  title: string;
-  description?: string;
-  tags: string[];
-  columnId: string;
-}
-
-interface BoardState {
-  columns: Column[];
-  items: TodoItem[];
-}
-
-interface TodoListProps {
-  events: IEvent[] | null;
-}
-
-const STORAGE_KEY = 'todo-board';
-const LAST_POPULATE_KEY = 'todo-last-populate';
-const DEFAULT_COLUMNS: Column[] = [
-  { id: 'todo', title: 'Todo', color: '#1976d2' },
-  { id: 'completed', title: 'Completed', color: '#2e7d32' },
-];
-
-function loadBoard(): BoardState {
-  try {
-    return getStoredFilters<BoardState>(STORAGE_KEY) || { columns: DEFAULT_COLUMNS, items: [] };
-  } catch {
-    return { columns: DEFAULT_COLUMNS, items: [] };
-  }
-}
-
-function saveBoard(board: BoardState): void {
-  try {
-    setStoredFilters(STORAGE_KEY, board);
-  } catch {
-    console.error('Could not save todo board');
-  }
-}
+import { AddItemForm } from './components/AddItemForm';
+import { TodoColumn } from './components/TodoColumn';
+import { DEFAULT_COLUMNS, LAST_POPULATE_KEY, loadBoard, saveBoard } from './boardStorage';
+import type { BoardState, Column, TodoItem, TodoListProps } from './types';
 
 export function TodoList({ events }: TodoListProps) {
   const [board, setBoard] = useState<BoardState>(() => loadBoard());
   const [view, setView] = useState<'board' | 'list'>('board');
-  const [newTitle, setNewTitle] = useState('');
-  const [newDescription, setNewDescription] = useState('');
-  const [newTags, setNewTags] = useState('');
   const [draggingId, setDraggingId] = useState<string | null>(null);
-  const selectionRef = useRef<HTMLDivElement>(null);
+  const [search, setSearch] = useState('');
 
-  // Populate with today's all day events only once per day
+  // Populate tasks from today's events once per day
   useEffect(() => {
     if (!events?.length) return;
 
@@ -91,13 +34,7 @@ export function TodoList({ events }: TodoListProps) {
     setBoard(prev => {
       const additions = fullDay
         .filter(ev => !prev.items.some(t => t.id === ev.id))
-        .map(ev => ({
-          id: ev.id,
-          title: ev.title,
-          description: undefined,
-          tags: [],
-          columnId: 'todo',
-        }));
+        .map(ev => ({ id: ev.id, title: ev.title, description: undefined, tags: [], columnId: 'todo' }));
       if (!additions.length) return prev;
       const updated = { ...prev, items: [...prev.items, ...additions] };
       saveBoard(updated);
@@ -107,28 +44,20 @@ export function TodoList({ events }: TodoListProps) {
     setStoredFilters(LAST_POPULATE_KEY, todayKey);
   }, [events]);
 
-  // Persist board on change
+  // Persist board whenever it changes
   useEffect(() => {
     saveBoard(board);
   }, [board]);
 
-  const handleAddItem = () => {
-    const title = newTitle.trim();
-    if (!title) return;
+  const handleAddItem = (title: string, description: string, tags: string[]) => {
     const item: TodoItem = {
       id: `todo-${Date.now()}`,
       title,
-      description: newDescription.trim() || undefined,
-      tags: newTags
-        .split(',')
-        .map(t => t.trim())
-        .filter(Boolean),
+      description: description || undefined,
+      tags,
       columnId: 'todo',
     };
     setBoard(prev => ({ ...prev, items: [...prev.items, item] }));
-    setNewTitle('');
-    setNewDescription('');
-    setNewTags('');
   };
 
   const handleEditItem = (id: string) => {
@@ -138,7 +67,6 @@ export function TodoList({ events }: TodoListProps) {
     if (!title.trim()) return;
     const description = window.prompt('Edit description', item.description || '') ?? '';
     const tagsString = window.prompt('Edit tags comma separated', item.tags.join(', ')) ?? '';
-
     const tags = tagsString
       .split(',')
       .map(t => t.trim())
@@ -146,11 +74,7 @@ export function TodoList({ events }: TodoListProps) {
 
     setBoard(prev => ({
       ...prev,
-      items: prev.items.map(t =>
-        t.id === id
-          ? { ...t, title: title.trim(), description: description.trim() || undefined, tags }
-          : t,
-      ),
+      items: prev.items.map(t => (t.id === id ? { ...t, title: title.trim(), description: description.trim() || undefined, tags } : t)),
     }));
   };
 
@@ -161,12 +85,9 @@ export function TodoList({ events }: TodoListProps) {
   const handleCompleteItem = (id: string) => {
     setBoard(prev => {
       const completedColumn =
-        prev.columns.find(c => c.title.toLowerCase() === 'completed') ||
-        prev.columns.find(c => c.id === 'completed');
+        prev.columns.find(c => c.title.toLowerCase() === 'completed') || prev.columns.find(c => c.id === 'completed');
       const columnId = completedColumn ? completedColumn.id : 'completed';
-      const columns = completedColumn
-        ? prev.columns
-        : [...prev.columns, { id: 'completed', title: 'Completed', color: '#2e7d32' }];
+      const columns = completedColumn ? prev.columns : [...prev.columns, { id: 'completed', title: 'Completed', color: '#2e7d32' }];
       const items = prev.items.map(t => (t.id === id ? { ...t, columnId } : t));
       return { columns, items };
     });
@@ -199,9 +120,28 @@ export function TodoList({ events }: TodoListProps) {
     }));
   };
 
+  const handleClearCompleted = () => {
+    setBoard(prev => ({ ...prev, items: prev.items.filter(i => i.columnId !== 'completed') }));
+  };
+
   const handleDragStart = (event: React.DragEvent<HTMLDivElement>, id: string) => {
     event.dataTransfer.effectAllowed = 'move';
     setDraggingId(id);
+  };
+
+  const handleDragOverItem = (event: React.DragEvent<HTMLDivElement>, overId: string) => {
+    event.preventDefault();
+    if (!draggingId || draggingId === overId) return;
+
+    setBoard(prev => {
+      const items = [...prev.items];
+      const from = items.findIndex(i => i.id === draggingId);
+      const to = items.findIndex(i => i.id === overId);
+      if (from === -1 || to === -1) return prev;
+      const [moved] = items.splice(from, 1);
+      items.splice(to, 0, moved);
+      return { ...prev, items };
+    });
   };
 
   const handleDrop = (event: React.DragEvent<HTMLDivElement>, columnId: string) => {
@@ -215,79 +155,28 @@ export function TodoList({ events }: TodoListProps) {
     }));
   };
 
-  const renderItem = (item: TodoItem) => {
-    const column = board.columns.find(c => c.id === item.columnId);
-    if (!column) return null;
-
-    return (
-      <Box
-        key={item.id}
-        data-todo-id={item.id}
-        draggable
-        onDragStart={e => handleDragStart(e, item.id)}
-        sx={{
-          p: 1,
-          border: '1px solid',
-          borderColor: column.color,
-          borderRadius: 1,
-          mb: 1,
-          position: 'relative',
-        }}
-      >
-        <Stack direction="row" justifyContent="space-between" alignItems="center">
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Typography variant="body1">{item.title}</Typography>
-            {item.description && (
-              <Tooltip title="Has description">
-                <AddIcon fontSize="small" />
-              </Tooltip>
-            )}
-          </Stack>
-          <Stack direction="row" spacing={1} sx={{ visibility: 'hidden' }} className="todo-actions">
-            <IconButton size="small" onClick={() => handleEditItem(item.id)}>
-              <EditIcon fontSize="inherit" />
-            </IconButton>
-            <IconButton size="small" onClick={() => handleCompleteItem(item.id)}>
-              <CheckIcon fontSize="inherit" />
-            </IconButton>
-            <IconButton size="small" onClick={() => handleDeleteItem(item.id)}>
-              <DeleteIcon fontSize="inherit" />
-            </IconButton>
-          </Stack>
-        </Stack>
-        <Stack direction="row" spacing={1} mt={0.5} flexWrap="wrap">
-          {item.tags.map(tag => (
-            <Chip key={tag} label={tag} size="small" />
-          ))}
-        </Stack>
-      </Box>
-    );
-  };
+  const filteredItems = board.items.filter(item => {
+    if (!search.trim()) return true;
+    const term = search.toLowerCase();
+    return item.title.toLowerCase().includes(term) || item.tags.some(t => t.toLowerCase().includes(term));
+  });
 
   const renderColumn = (column: Column) => {
-    const items = board.items.filter(i => i.columnId === column.id);
+    const items = filteredItems.filter(i => i.columnId === column.id);
     return (
-      <Box
+      <TodoColumn
         key={column.id}
-        onDragOver={e => e.preventDefault()}
-        onDrop={e => handleDrop(e, column.id)}
-        sx={{ width: 250, p: 1, bgcolor: alpha(column.color, 0.1), borderRadius: 1 }}
-      >
-        <Stack direction="row" alignItems="center" justifyContent="space-between" mb={1}>
-          <Typography variant="h6" sx={{ color: column.color }}>
-            {column.title}
-          </Typography>
-          <Stack direction="row" spacing={0}>
-            <IconButton size="small" onClick={() => handleRenameColumn(column.id)}>
-              <EditIcon fontSize="inherit" />
-            </IconButton>
-            <IconButton size="small" onClick={() => handleDeleteColumn(column.id)}>
-              <DeleteIcon fontSize="inherit" />
-            </IconButton>
-          </Stack>
-        </Stack>
-        {items.map(renderItem)}
-      </Box>
+        column={column}
+        items={items}
+        onRenameColumn={handleRenameColumn}
+        onDeleteColumn={handleDeleteColumn}
+        onEditItem={handleEditItem}
+        onDeleteItem={handleDeleteItem}
+        onCompleteItem={handleCompleteItem}
+        onDragStart={handleDragStart}
+        onDragOverItem={handleDragOverItem}
+        onDrop={handleDrop}
+      />
     );
   };
 
@@ -297,11 +186,22 @@ export function TodoList({ events }: TodoListProps) {
         <Typography variant="h6" sx={{ color: col.color }}>
           {col.title}
         </Typography>
-        {board.items
+        {filteredItems
           .filter(i => i.columnId === col.id)
           .map(item => (
             <Box key={item.id} mb={1}>
-              {renderItem(item)}
+              <TodoColumn
+                column={col}
+                items={[item]}
+                onRenameColumn={() => undefined}
+                onDeleteColumn={() => undefined}
+                onEditItem={handleEditItem}
+                onDeleteItem={handleDeleteItem}
+                onCompleteItem={handleCompleteItem}
+                onDragStart={handleDragStart}
+                onDragOverItem={handleDragOverItem}
+                onDrop={handleDrop}
+              />
             </Box>
           ))}
       </Box>
@@ -309,16 +209,15 @@ export function TodoList({ events }: TodoListProps) {
   };
 
   return (
-    <Box ref={selectionRef} sx={{ position: 'relative' }}>
-      <Stack direction="row" spacing={1} mb={2}>
+    <Box sx={{ position: 'relative' }}>
+      <Stack direction="row" spacing={1} mb={2} alignItems="center">
         <Typography variant="h6">Todo List</Typography>
+        <TextField size="small" placeholder="Search" value={search} onChange={e => setSearch(e.target.value)} />
         <Box flexGrow={1} />
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={view === 'board' ? <ListIcon /> : <ViewColumnIcon />}
-          onClick={() => setView(v => (v === 'board' ? 'list' : 'board'))}
-        >
+        <Button variant="outlined" size="small" onClick={handleClearCompleted}>
+          Clear Completed
+        </Button>
+        <Button variant="outlined" size="small" startIcon={view === 'board' ? <ListIcon /> : <ViewColumnIcon />} onClick={() => setView(v => (v === 'board' ? 'list' : 'board'))}>
           {view === 'board' ? 'List view' : 'Board view'}
         </Button>
         <Button variant="outlined" size="small" startIcon={<AddIcon />} onClick={handleAddColumn}>
@@ -334,22 +233,7 @@ export function TodoList({ events }: TodoListProps) {
         <Box>{renderList()}</Box>
       )}
 
-      <Stack mt={2} spacing={1}>
-        <TextField label="Title" value={newTitle} onChange={e => setNewTitle(e.target.value)} />
-        <TextField
-          label="Description"
-          value={newDescription}
-          onChange={e => setNewDescription(e.target.value)}
-        />
-        <TextField
-          label="Tags (comma separated)"
-          value={newTags}
-          onChange={e => setNewTags(e.target.value)}
-        />
-        <Button variant="contained" onClick={handleAddItem} startIcon={<AddIcon />}>
-          Add Item
-        </Button>
-      </Stack>
+      <AddItemForm onAdd={handleAddItem} />
 
       <style jsx>{`
         .todo-actions {

--- a/src/widgets/TodoList/types.ts
+++ b/src/widgets/TodoList/types.ts
@@ -1,0 +1,22 @@
+export interface Column {
+  id: string;
+  title: string;
+  color: string;
+}
+
+export interface TodoItem {
+  id: string;
+  title: string;
+  description?: string;
+  tags: string[];
+  columnId: string;
+}
+
+export interface BoardState {
+  columns: Column[];
+  items: TodoItem[];
+}
+
+export interface TodoListProps {
+  events: import('@/types/IEvent').IEvent[] | null;
+}


### PR DESCRIPTION
## Summary
- restructure TodoList into smaller components
- add state persistence helpers
- create AddItemForm, TodoItemCard and TodoColumn components
- support search, description dialog, item order dragging and clearing completed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6868798a26a88329ad238ca68d1d0b63