### PR TITLE
Fix TodoList board handling

### DIFF
--- a/src/widgets/TodoList/AddColumnModal.tsx
+++ b/src/widgets/TodoList/AddColumnModal.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  Stack,
+  TextField,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+
+const COLOR_KEYS = ['primary', 'secondary', 'success', 'info', 'warning', 'error'] as const;
+
+type ColorKey = (typeof COLOR_KEYS)[number];
+
+interface AddColumnModalProps {
+  open: boolean;
+  onAdd: (title: string, color: string) => void;
+  onClose: () => void;
+}
+
+export function AddColumnModal({ open, onAdd, onClose }: AddColumnModalProps) {
+  const [title, setTitle] = useState('');
+  const [color, setColor] = useState<ColorKey>('primary');
+  const theme = useTheme();
+
+  const handleAdd = () => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    onAdd(trimmed, theme.palette[color].main);
+    setTitle('');
+    setColor('primary');
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Add Column</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} mt={1}>
+          <TextField label="Title" value={title} onChange={e => setTitle(e.target.value)} />
+          <TextField
+            select
+            label="Color"
+            value={color}
+            onChange={e => setColor(e.target.value as ColorKey)}
+          >
+            {COLOR_KEYS.map(c => (
+              <MenuItem key={c} value={c} style={{ color: theme.palette[c].main }}>
+                {c}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" onClick={handleAdd}>
+          Add
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/widgets/TodoList/AddItemInput.tsx
+++ b/src/widgets/TodoList/AddItemInput.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
-import { Box, TextField } from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
+import { Box, IconButton, TextField } from '@mui/material';
 
 interface AddItemInputProps {
   columnId: string;
@@ -10,18 +11,22 @@ interface AddItemInputProps {
 export function AddItemInput({ columnId, onAdd }: AddItemInputProps) {
   const [value, setValue] = useState('');
 
+  const addItem = () => {
+    const title = value.trim();
+    if (!title) return;
+    onAdd(columnId, title);
+    setValue('');
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       e.preventDefault();
-      const title = value.trim();
-      if (!title) return;
-      onAdd(columnId, title);
-      setValue('');
+      addItem();
     }
   };
 
   return (
-    <Box mt={1}>
+    <Box mt={1} sx={{ display: 'flex', gap: 1 }}>
       <TextField
         fullWidth
         size="small"
@@ -30,6 +35,9 @@ export function AddItemInput({ columnId, onAdd }: AddItemInputProps) {
         onChange={e => setValue(e.target.value)}
         onKeyDown={handleKeyDown}
       />
+      <IconButton color="primary" onClick={addItem}>
+        <CheckIcon fontSize="small" />
+      </IconButton>
     </Box>
   );
 }

--- a/src/widgets/TodoList/TodoColumn.tsx
+++ b/src/widgets/TodoList/TodoColumn.tsx
@@ -14,6 +14,7 @@ interface TodoColumnProps {
   onDeleteColumn: (id: string) => void;
   onChangeColor: (id: string) => void;
   onEditItem: (id: string) => void;
+  onRenameItem: (id: string, title: string) => void;
   onDeleteItem: (id: string) => void;
   onCompleteItem: (id: string) => void;
   onAddItem: (columnId: string, title: string) => void;
@@ -33,6 +34,7 @@ export function TodoColumn({
   onDeleteColumn,
   onChangeColor,
   onEditItem,
+  onRenameItem,
   onDeleteItem,
   onCompleteItem,
   onAddItem,
@@ -54,7 +56,13 @@ export function TodoColumn({
       }}
       onDragEnd={onColumnDragEnd}
       onDrop={e => onDrop(e, column.id)}
-      sx={{ width: 250, p: 1, bgcolor: alpha(column.color, 0.1), borderRadius: 1 }}
+      sx={{
+        minWidth: 250,
+        width: 'fit-content',
+        p: 1,
+        bgcolor: alpha(column.color, 0.1),
+        borderRadius: 1,
+      }}
     >
       {!hideHeader && (
         <Stack direction="row" alignItems="center" justifyContent="space-between" mb={1}>
@@ -68,7 +76,12 @@ export function TodoColumn({
             <IconButton size="small" onClick={() => onChangeColor(column.id)}>
               <PaletteIcon fontSize="inherit" />
             </IconButton>
-            <IconButton size="small" onClick={() => onDeleteColumn(column.id)}>
+            <IconButton
+              size="small"
+              onClick={() => onDeleteColumn(column.id)}
+              disabled={column.id === 'done'}
+              color="error"
+            >
               <DeleteIcon fontSize="inherit" />
             </IconButton>
           </Stack>
@@ -79,7 +92,8 @@ export function TodoColumn({
           key={item.id}
           item={item}
           column={column}
-          onEdit={onEditItem}
+          onOpen={onEditItem}
+          onRename={onRenameItem}
           onDelete={onDeleteItem}
           onComplete={onCompleteItem}
           onDragStart={onDragStart}


### PR DESCRIPTION
## Summary
- add modal for adding new columns with MUI theme colors
- rename items inline from TodoItemCard
- adjust TodoColumn layout and disable deleting Done column
- support board/list layouts with a single component
- add confirm/delete prompts and color choices

## Testing
- `npm run format`
- `npm run build` *(fails: next not found)*
- `npx eslint 'src/**/*.{ts,tsx}'` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686888ae01008329902e88ba0b5d0977