### PR TITLE
Add basic PWA support

### DIFF
--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text y=".9em" font-size="90">🤓</text>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Smart Desk",
+  "short_name": "SmartDesk",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,46 @@
+const CACHE_NAME = 'smart-desk-cache-v1';
+
+const urlsToCache = [
+  '/',
+  '/manifest.json',
+  '/icon.svg',
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+
+      return fetch(event.request)
+        .then(response => {
+          if (!response || response.status !== 200) return response;
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then(cache => {
+            cache.put(event.request, responseClone);
+          });
+          return response;
+        })
+        .catch(() => cached);
+    })
+  );
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { SessionProvider } from 'next-auth/react';
 import { AppThemeProvider } from '@/providers/AppThemeProvider';
 import { LocationProvider } from '@/providers/LocationProvider';
 import { ReactQueryProvider } from '@/providers/ReactQueryProvider';
+import { ServiceWorkerProvider } from '@/providers/ServiceWorkerProvider';
 import { poppins } from '@/styles/fonts';
 
 interface RootLayoutProps {
@@ -16,15 +17,24 @@ interface RootLayoutProps {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="en">
-      <title>Smart Desk</title>
+      <head>
+        <title>Smart Desk</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#000000" />
+        <link rel="manifest" href="/manifest.json" />
+        <link rel="icon" href="/icon.svg" type="image/svg+xml" />
+        <link rel="apple-touch-icon" href="/icon.svg" />
+      </head>
 
       <body suppressHydrationWarning className={poppins.variable}>
         <SessionProvider>
-          <LocationProvider>
-            <ReactQueryProvider>
-              <AppThemeProvider>{children}</AppThemeProvider>
-            </ReactQueryProvider>
-          </LocationProvider>
+          <ServiceWorkerProvider>
+            <LocationProvider>
+              <ReactQueryProvider>
+                <AppThemeProvider>{children}</AppThemeProvider>
+              </ReactQueryProvider>
+            </LocationProvider>
+          </ServiceWorkerProvider>
         </SessionProvider>
       </body>
     </html>

--- a/src/providers/ServiceWorkerProvider.tsx
+++ b/src/providers/ServiceWorkerProvider.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+
+interface ServiceWorkerProviderProps {
+  children: ReactNode;
+}
+
+export function ServiceWorkerProvider({ children }: ServiceWorkerProviderProps) {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/sw.js')
+        .catch(err => console.error('Service Worker registration failed:', err));
+    }
+  }, []);
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- add a minimal web app manifest and icon
- register a service worker
- cache assets for offline use
- expose manifest and PWA meta tags in the root layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_686b31f6aa888329b2b70c664c314d19