### PR TITLE
Integrate Firebase Firestore

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,8 @@ import { AppThemeProvider } from '@/providers/AppThemeProvider';
 import { LocationProvider } from '@/providers/LocationProvider';
 import { ReactQueryProvider } from '@/providers/ReactQueryProvider';
 import { ServiceWorkerProvider } from '@/providers/ServiceWorkerProvider';
+import { FirebaseAuthProvider } from '@/providers/FirebaseAuthProvider';
+import { FirestoreSyncProvider } from '@/providers/FirestoreSyncProvider';
 import { poppins } from '@/styles/fonts';
 
 import '@/lib/dragDropTouch';
@@ -30,13 +32,17 @@ export default function RootLayout({ children }: RootLayoutProps) {
 
       <body suppressHydrationWarning className={poppins.variable}>
         <SessionProvider>
-          <ServiceWorkerProvider>
-            <LocationProvider>
-              <ReactQueryProvider>
-                <AppThemeProvider>{children}</AppThemeProvider>
-              </ReactQueryProvider>
-            </LocationProvider>
-          </ServiceWorkerProvider>
+          <FirebaseAuthProvider>
+            <FirestoreSyncProvider>
+              <ServiceWorkerProvider>
+                <LocationProvider>
+                  <ReactQueryProvider>
+                    <AppThemeProvider>{children}</AppThemeProvider>
+                  </ReactQueryProvider>
+                </LocationProvider>
+              </ServiceWorkerProvider>
+            </FirestoreSyncProvider>
+          </FirebaseAuthProvider>
         </SessionProvider>
       </body>
     </html>

--- a/src/providers/FirebaseAuthProvider.tsx
+++ b/src/providers/FirebaseAuthProvider.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+import { GoogleAuthProvider, signInWithCredential, signOut } from 'firebase/auth';
+import { auth } from '@/services/firebase';
+import { useSession } from 'next-auth/react';
+
+interface FirebaseAuthProviderProps {
+  children: ReactNode;
+}
+
+export function FirebaseAuthProvider({ children }: FirebaseAuthProviderProps) {
+  const { data: session } = useSession();
+
+  useEffect(() => {
+    if (session?.accessToken) {
+      const credential = GoogleAuthProvider.credential(null, session.accessToken);
+      signInWithCredential(auth, credential).catch(err =>
+        console.error('Firebase sign in failed', err),
+      );
+    } else {
+      signOut(auth).catch(() => {});
+    }
+  }, [session]);
+
+  return <>{children}</>;
+}

--- a/src/providers/FirestoreSyncProvider.tsx
+++ b/src/providers/FirestoreSyncProvider.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '@/services/firebase';
+import { subscribeToBoard } from '@/services/firestore/board';
+import { subscribeToLocalEvents } from '@/services/firestore/localEvents';
+import { subscribeToIcsCalendars } from '@/services/firestore/icsCalendars';
+import { useTodoBoardStore } from '@/store/todoBoardStore';
+import { DEFAULT_BOARD } from '@/widgets/TodoList/boardStorage';
+import { useEventStore } from '@/store/eventStore';
+import { loadLocalEvents } from '@/utils/localEventsStorage';
+import type { IcsCalendarConfig } from '@/types/IcsCalendarConfig';
+import { getStoredFilters, setStoredFilters } from '@/utils/localStorageUtils';
+
+const ICS_STORAGE_KEY = 'ics-calendars';
+
+interface FirestoreSyncProviderProps {
+  children: ReactNode;
+}
+
+export function FirestoreSyncProvider({ children }: FirestoreSyncProviderProps) {
+  const setBoard = useTodoBoardStore(state => state.setBoard);
+  const setLocalEvents = useEventStore(state => state.setLocalEvents);
+
+  useEffect(() => {
+    let unsubBoard: (() => void) | undefined;
+    let unsubEvents: (() => void) | undefined;
+    let unsubCalendars: (() => void) | undefined;
+
+    const stopListening = () => {
+      unsubBoard?.();
+      unsubEvents?.();
+      unsubCalendars?.();
+      unsubBoard = undefined;
+      unsubEvents = undefined;
+      unsubCalendars = undefined;
+    };
+
+    return onAuthStateChanged(auth, user => {
+      stopListening();
+      if (user) {
+        unsubBoard = subscribeToBoard(user.uid, board => {
+          setBoard(board ?? DEFAULT_BOARD);
+        });
+        unsubEvents = subscribeToLocalEvents(user.uid, events => {
+          setLocalEvents(events);
+        });
+        unsubCalendars = subscribeToIcsCalendars(user.uid, calendars => {
+          setStoredFilters(ICS_STORAGE_KEY, calendars);
+        });
+      } else {
+        // fallback to localStorage when signed out
+        setBoard(DEFAULT_BOARD);
+        setLocalEvents(loadLocalEvents());
+        const stored = getStoredFilters<IcsCalendarConfig[]>(ICS_STORAGE_KEY) ?? [];
+        setStoredFilters(ICS_STORAGE_KEY, stored);
+      }
+    });
+  }, [setBoard, setLocalEvents]);
+
+  return <>{children}</>;
+}

--- a/src/services/firestore/board.ts
+++ b/src/services/firestore/board.ts
@@ -1,0 +1,23 @@
+import { doc, getDoc, onSnapshot, setDoc, Unsubscribe } from 'firebase/firestore';
+import { db } from '../firebase';
+import type { BoardState } from '@/widgets/TodoList/types';
+
+const docPath = (uid: string) => doc(db, 'users', uid, 'board', 'state');
+
+export async function loadBoardFromFirestore(uid: string): Promise<BoardState | null> {
+  const snap = await getDoc(docPath(uid));
+  return snap.exists() ? (snap.data() as BoardState) : null;
+}
+
+export function subscribeToBoard(
+  uid: string,
+  cb: (board: BoardState | null) => void,
+): Unsubscribe {
+  return onSnapshot(docPath(uid), snap => {
+    cb(snap.exists() ? (snap.data() as BoardState) : null);
+  });
+}
+
+export function saveBoardToFirestore(uid: string, board: BoardState): Promise<void> {
+  return setDoc(docPath(uid), board);
+}

--- a/src/services/firestore/icsCalendars.ts
+++ b/src/services/firestore/icsCalendars.ts
@@ -1,0 +1,29 @@
+import { doc, getDoc, onSnapshot, setDoc, Unsubscribe } from 'firebase/firestore';
+import { db } from '../firebase';
+import type { IcsCalendarConfig } from '@/types/IcsCalendarConfig';
+
+const docPath = (uid: string) => doc(db, 'users', uid, 'icsCalendars', 'config');
+
+export async function loadIcsCalendarsFromFirestore(uid: string): Promise<IcsCalendarConfig[]> {
+  const snap = await getDoc(docPath(uid));
+  return snap.exists() ? ((snap.data().calendars as IcsCalendarConfig[]) || []) : [];
+}
+
+export function subscribeToIcsCalendars(
+  uid: string,
+  cb: (calendars: IcsCalendarConfig[]) => void,
+): Unsubscribe {
+  return onSnapshot(docPath(uid), snap => {
+    const calendars = snap.exists()
+      ? ((snap.data().calendars as IcsCalendarConfig[]) || [])
+      : [];
+    cb(calendars);
+  });
+}
+
+export function saveIcsCalendarsToFirestore(
+  uid: string,
+  calendars: IcsCalendarConfig[],
+): Promise<void> {
+  return setDoc(docPath(uid), { calendars });
+}

--- a/src/services/firestore/localEvents.ts
+++ b/src/services/firestore/localEvents.ts
@@ -1,0 +1,24 @@
+import { doc, getDoc, onSnapshot, setDoc, Unsubscribe } from 'firebase/firestore';
+import { db } from '../firebase';
+import type { IEvent } from '@/types/IEvent';
+
+const docPath = (uid: string) => doc(db, 'users', uid, 'localEvents', 'list');
+
+export async function loadLocalEventsFromFirestore(uid: string): Promise<IEvent[]> {
+  const snap = await getDoc(docPath(uid));
+  return snap.exists() ? ((snap.data().events as IEvent[]) || []) : [];
+}
+
+export function subscribeToLocalEvents(
+  uid: string,
+  cb: (events: IEvent[]) => void,
+): Unsubscribe {
+  return onSnapshot(docPath(uid), snap => {
+    const events = snap.exists() ? ((snap.data().events as IEvent[]) || []) : [];
+    cb(events);
+  });
+}
+
+export function saveLocalEventsToFirestore(uid: string, events: IEvent[]): Promise<void> {
+  return setDoc(docPath(uid), { events });
+}

--- a/src/store/eventStore.ts
+++ b/src/store/eventStore.ts
@@ -12,6 +12,7 @@ interface EventState {
   trash: IEvent[];
   hiddenEvents: string[];
   setRemoteEvents: (list: IEvent[]) => void;
+  setLocalEvents: (events: IEvent[]) => void;
   addLocalEvent: (event: IEvent) => void;
   updateLocalEvent: (event: IEvent) => void;
   deleteEvent: (id: string) => void;
@@ -38,6 +39,11 @@ export const useEventStore = create<EventState>((set, get) => ({
       set({ remoteEvents: filtered, events: allEvents });
     }
   },
+  setLocalEvents: events =>
+    set(state => ({
+      localEvents: events,
+      events: [...state.remoteEvents, ...events],
+    })),
   addLocalEvent: event =>
     set(state => {
       const localEvents = [...state.localEvents, event];

--- a/src/utils/localEventsStorage.ts
+++ b/src/utils/localEventsStorage.ts
@@ -1,5 +1,9 @@
 import { IEvent } from '@/types/IEvent';
 import { getStoredFilters, setStoredFilters } from '@/utils/localStorageUtils';
+import { auth } from '@/services/firebase';
+import {
+  saveLocalEventsToFirestore,
+} from '@/services/firestore/localEvents';
 
 const STORAGE_KEY = 'local-events';
 
@@ -12,6 +16,13 @@ export function loadLocalEvents(): IEvent[] {
 }
 
 export function saveLocalEvents(events: IEvent[]): void {
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    saveLocalEventsToFirestore(uid, events).catch(err =>
+      console.error('Failed to save events to Firestore', err),
+    );
+  }
+
   try {
     setStoredFilters(STORAGE_KEY, events);
   } catch {

--- a/src/widgets/TodoList/boardStorage.ts
+++ b/src/widgets/TodoList/boardStorage.ts
@@ -1,6 +1,8 @@
 import { getStoredFilters, setStoredFilters } from '@/utils/localStorageUtils';
 import { COLUMN_COLORS } from '@/widgets/TodoList/ColumnModal';
 import { BoardState, Column } from '@/widgets/TodoList/types';
+import { auth } from '@/services/firebase';
+import { saveBoardToFirestore } from '@/services/firestore/board';
 
 export const STORAGE_KEY = 'todo-board';
 export const LAST_POPULATE_KEY = 'todo-last-populate';
@@ -33,6 +35,13 @@ export function loadBoard(): BoardState {
 }
 
 export function saveBoard(board: BoardState): void {
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    saveBoardToFirestore(uid, board).catch(err =>
+      console.error('Failed to save board to Firestore', err),
+    );
+  }
+
   try {
     setStoredFilters(STORAGE_KEY, board);
   } catch {


### PR DESCRIPTION
## Summary
- connect Firebase auth to NextAuth session
- sync Firestore board, local events and calendar configs
- store changes in Firestore when logged in
- watch Firestore updates in provider

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686c69f8ff088329949b3a173a053262