### PR TITLE
Add comprehensive Firestore sync

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -25,6 +25,9 @@ function validateScopes(scope?: string) {
 
 async function refreshAccessToken(token: JWT) {
   try {
+    if (!token.refreshToken) {
+      throw new Error('Missing refresh token');
+    }
     if (process.env.NODE_ENV === 'development') {
       console.log('Refreshing access token...');
     }

--- a/src/providers/FirestoreSyncProvider.tsx
+++ b/src/providers/FirestoreSyncProvider.tsx
@@ -8,11 +8,25 @@ import { auth } from '@/services/firebase';
 import { subscribeToBoard } from '@/services/firestore/board';
 import { subscribeToIcsCalendars } from '@/services/firestore/icsCalendars';
 import { subscribeToLocalEvents } from '@/services/firestore/localEvents';
+import { subscribeToRemoteEvents } from '@/services/firestore/remoteEvents';
+import { subscribeToHiddenEvents } from '@/services/firestore/hiddenEvents';
+import { subscribeToTagPresets } from '@/services/firestore/tagPresets';
+import { subscribeToTodoPrefs } from '@/services/firestore/todoPrefs';
 import { useEventStore } from '@/store/eventStore';
 import { useTodoBoardStore } from '@/store/todoBoardStore';
+import { useTodoPrefsStore } from '@/store/todoPrefsStore';
 import type { IcsCalendarConfig } from '@/types/IcsCalendarConfig';
 import { loadLocalEvents } from '@/utils/localEventsStorage';
-import { getStoredFilters, setStoredFilters } from '@/utils/localStorageUtils';
+import {
+  getStoredFilters,
+  setStoredFilters,
+} from '@/utils/localStorageUtils';
+import {
+  loadHiddenEventIds,
+  saveHiddenEventIds,
+  HIDDEN_EVENTS_KEY,
+} from '@/utils/hiddenEventsStorage';
+import { saveTagPresets, TAG_PRESETS_KEY } from '@/utils/tagPresetsStorage';
 import { DEFAULT_BOARD } from '@/widgets/TodoList/boardStorage';
 
 const ICS_STORAGE_KEY = 'ics-calendars';
@@ -24,19 +38,34 @@ interface FirestoreSyncProviderProps {
 export function FirestoreSyncProvider({ children }: FirestoreSyncProviderProps) {
   const setBoard = useTodoBoardStore(state => state.setBoard);
   const setLocalEvents = useEventStore(state => state.setLocalEvents);
+  const setRemoteEvents = useEventStore(state => state.setRemoteEvents);
+  const setHiddenEvents = useEventStore(state => state.setHiddenEvents);
+  const setPrefs = useTodoPrefsStore(state => state.setPrefs);
 
   useEffect(() => {
     let unsubBoard: (() => void) | undefined;
     let unsubEvents: (() => void) | undefined;
     let unsubCalendars: (() => void) | undefined;
+    let unsubRemote: (() => void) | undefined;
+    let unsubHidden: (() => void) | undefined;
+    let unsubPresets: (() => void) | undefined;
+    let unsubPrefs: (() => void) | undefined;
 
     const stopListening = () => {
       unsubBoard?.();
       unsubEvents?.();
       unsubCalendars?.();
+      unsubRemote?.();
+      unsubHidden?.();
+      unsubPresets?.();
+      unsubPrefs?.();
       unsubBoard = undefined;
       unsubEvents = undefined;
       unsubCalendars = undefined;
+      unsubRemote = undefined;
+      unsubHidden = undefined;
+      unsubPresets = undefined;
+      unsubPrefs = undefined;
     };
 
     return onAuthStateChanged(auth, user => {
@@ -51,15 +80,31 @@ export function FirestoreSyncProvider({ children }: FirestoreSyncProviderProps) 
         unsubCalendars = subscribeToIcsCalendars(user.uid, calendars => {
           setStoredFilters(ICS_STORAGE_KEY, calendars);
         });
+        unsubRemote = subscribeToRemoteEvents(user.uid, ev => {
+          setRemoteEvents(ev);
+        });
+        unsubHidden = subscribeToHiddenEvents(user.uid, ids => {
+          setHiddenEvents(ids);
+          saveHiddenEventIds(ids);
+        });
+        unsubPresets = subscribeToTagPresets(user.uid, presets => {
+          saveTagPresets(presets);
+        });
+        unsubPrefs = subscribeToTodoPrefs(user.uid, prefs => {
+          if (prefs) setPrefs(prefs);
+        });
       } else {
         // fallback to localStorage when signed out
         setBoard(DEFAULT_BOARD);
         setLocalEvents(loadLocalEvents());
+        setRemoteEvents([]);
+        setHiddenEvents(loadHiddenEventIds());
         const stored = getStoredFilters<IcsCalendarConfig[]>(ICS_STORAGE_KEY) ?? [];
         setStoredFilters(ICS_STORAGE_KEY, stored);
+        saveTagPresets(getStoredFilters(TAG_PRESETS_KEY) ?? []);
       }
     });
-  }, [setBoard, setLocalEvents]);
+  }, [setBoard, setLocalEvents, setRemoteEvents, setHiddenEvents, setPrefs]);
 
   return <>{children}</>;
 }

--- a/src/services/firestore/hiddenEvents.ts
+++ b/src/services/firestore/hiddenEvents.ts
@@ -1,0 +1,24 @@
+import { doc, getDoc, onSnapshot, setDoc, Unsubscribe } from 'firebase/firestore';
+
+import { db } from '@/services/firebase';
+
+const docPath = (uid: string) => doc(db, 'users', uid, 'settings', 'hiddenEvents');
+
+export async function loadHiddenEventsFromFirestore(uid: string): Promise<string[]> {
+  const snap = await getDoc(docPath(uid));
+  return snap.exists() ? ((snap.data().ids as string[]) || []) : [];
+}
+
+export function subscribeToHiddenEvents(
+  uid: string,
+  cb: (ids: string[]) => void,
+): Unsubscribe {
+  return onSnapshot(docPath(uid), snap => {
+    const ids = snap.exists() ? ((snap.data().ids as string[]) || []) : [];
+    cb(ids);
+  });
+}
+
+export function saveHiddenEventsToFirestore(uid: string, ids: string[]): Promise<void> {
+  return setDoc(docPath(uid), { ids });
+}

--- a/src/services/firestore/remoteEvents.ts
+++ b/src/services/firestore/remoteEvents.ts
@@ -1,0 +1,25 @@
+import { doc, getDoc, onSnapshot, setDoc, Unsubscribe } from 'firebase/firestore';
+
+import { db } from '@/services/firebase';
+import type { IEvent } from '@/types/IEvent';
+
+const docPath = (uid: string) => doc(db, 'users', uid, 'remoteEvents', 'list');
+
+export async function loadRemoteEventsFromFirestore(uid: string): Promise<IEvent[]> {
+  const snap = await getDoc(docPath(uid));
+  return snap.exists() ? ((snap.data().events as IEvent[]) || []) : [];
+}
+
+export function subscribeToRemoteEvents(
+  uid: string,
+  cb: (events: IEvent[]) => void,
+): Unsubscribe {
+  return onSnapshot(docPath(uid), snap => {
+    const events = snap.exists() ? ((snap.data().events as IEvent[]) || []) : [];
+    cb(events);
+  });
+}
+
+export function saveRemoteEventsToFirestore(uid: string, events: IEvent[]): Promise<void> {
+  return setDoc(docPath(uid), { events });
+}

--- a/src/services/firestore/tagPresets.ts
+++ b/src/services/firestore/tagPresets.ts
@@ -1,0 +1,25 @@
+import { doc, getDoc, onSnapshot, setDoc, Unsubscribe } from 'firebase/firestore';
+
+import { db } from '@/services/firebase';
+import type { TagPreset } from '@/utils/tagPresetsStorage';
+
+const docPath = (uid: string) => doc(db, 'users', uid, 'settings', 'tagPresets');
+
+export async function loadTagPresetsFromFirestore(uid: string): Promise<TagPreset[]> {
+  const snap = await getDoc(docPath(uid));
+  return snap.exists() ? ((snap.data().presets as TagPreset[]) || []) : [];
+}
+
+export function subscribeToTagPresets(
+  uid: string,
+  cb: (presets: TagPreset[]) => void,
+): Unsubscribe {
+  return onSnapshot(docPath(uid), snap => {
+    const presets = snap.exists() ? ((snap.data().presets as TagPreset[]) || []) : [];
+    cb(presets);
+  });
+}
+
+export function saveTagPresetsToFirestore(uid: string, presets: TagPreset[]): Promise<void> {
+  return setDoc(docPath(uid), { presets });
+}

--- a/src/services/firestore/todoPrefs.ts
+++ b/src/services/firestore/todoPrefs.ts
@@ -1,0 +1,25 @@
+import { doc, getDoc, onSnapshot, setDoc, Unsubscribe } from 'firebase/firestore';
+
+import { db } from '@/services/firebase';
+import type { TodoPrefsData } from '@/store/todoPrefsStore';
+
+const docPath = (uid: string) => doc(db, 'users', uid, 'settings', 'todoPrefs');
+
+export async function loadTodoPrefsFromFirestore(uid: string): Promise<TodoPrefsData | null> {
+  const snap = await getDoc(docPath(uid));
+  return snap.exists() ? ((snap.data() as TodoPrefsData) || null) : null;
+}
+
+export function subscribeToTodoPrefs(
+  uid: string,
+  cb: (prefs: TodoPrefsData | null) => void,
+): Unsubscribe {
+  return onSnapshot(docPath(uid), snap => {
+    const prefs = snap.exists() ? ((snap.data() as TodoPrefsData) || null) : null;
+    cb(prefs);
+  });
+}
+
+export function saveTodoPrefsToFirestore(uid: string, prefs: TodoPrefsData): Promise<void> {
+  return setDoc(docPath(uid), prefs);
+}

--- a/src/utils/hiddenEventsStorage.ts
+++ b/src/utils/hiddenEventsStorage.ts
@@ -1,15 +1,24 @@
+import { auth } from '@/services/firebase';
+import { saveHiddenEventsToFirestore } from '@/services/firestore/hiddenEvents';
 import { getStoredFilters, setStoredFilters } from '@/utils/localStorageUtils';
 
-const STORAGE_KEY = 'hidden-events';
+export const HIDDEN_EVENTS_KEY = 'hidden-events';
 
 export function loadHiddenEventIds(): string[] {
   try {
-    return getStoredFilters<string[]>(STORAGE_KEY) ?? [];
+    return getStoredFilters<string[]>(HIDDEN_EVENTS_KEY) ?? [];
   } catch {
     return [];
   }
 }
 
 export function saveHiddenEventIds(ids: string[]): void {
-  setStoredFilters(STORAGE_KEY, ids);
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    saveHiddenEventsToFirestore(uid, ids).catch(err =>
+      console.error('Failed to save hidden events to Firestore', err),
+    );
+  }
+
+  setStoredFilters(HIDDEN_EVENTS_KEY, ids);
 }

--- a/src/utils/remoteEventsStorage.ts
+++ b/src/utils/remoteEventsStorage.ts
@@ -1,0 +1,12 @@
+import { auth } from '@/services/firebase';
+import { saveRemoteEventsToFirestore } from '@/services/firestore/remoteEvents';
+import type { IEvent } from '@/types/IEvent';
+
+export function saveRemoteEvents(events: IEvent[]): void {
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    saveRemoteEventsToFirestore(uid, events).catch(err =>
+      console.error('Failed to save remote events to Firestore', err),
+    );
+  }
+}

--- a/src/utils/tagPresetsStorage.ts
+++ b/src/utils/tagPresetsStorage.ts
@@ -1,3 +1,5 @@
+import { auth } from '@/services/firebase';
+import { saveTagPresetsToFirestore } from '@/services/firestore/tagPresets';
 import { getStoredFilters, setStoredFilters } from '@/utils/localStorageUtils';
 
 export interface TagPreset {
@@ -5,12 +7,19 @@ export interface TagPreset {
   color: string;
 }
 
-const KEY = 'tag-presets';
+export const TAG_PRESETS_KEY = 'tag-presets';
 
 export function loadTagPresets(): TagPreset[] {
-  return getStoredFilters<TagPreset[]>(KEY) ?? [];
+  return getStoredFilters<TagPreset[]>(TAG_PRESETS_KEY) ?? [];
 }
 
 export function saveTagPresets(presets: TagPreset[]): void {
-  setStoredFilters(KEY, presets);
+  const uid = auth.currentUser?.uid;
+  if (uid) {
+    saveTagPresetsToFirestore(uid, presets).catch(err =>
+      console.error('Failed to save tag presets to Firestore', err),
+    );
+  }
+
+  setStoredFilters(TAG_PRESETS_KEY, presets);
 }

--- a/src/widgets/Settings/TagPresets.tsx
+++ b/src/widgets/Settings/TagPresets.tsx
@@ -16,7 +16,12 @@ import {
   TextField,
 } from '@mui/material';
 
-import { loadTagPresets, saveTagPresets, TagPreset } from '@/utils/tagPresetsStorage';
+import {
+  loadTagPresets,
+  saveTagPresets,
+  TagPreset,
+  TAG_PRESETS_KEY,
+} from '@/utils/tagPresetsStorage';
 import { COLUMN_COLORS } from '@/widgets/TodoList/ColumnModal';
 
 export function TagPresets() {
@@ -27,6 +32,14 @@ export function TagPresets() {
 
   useEffect(() => {
     setPresets(loadTagPresets());
+
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === TAG_PRESETS_KEY) {
+        setPresets(loadTagPresets());
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
   }, []);
 
   const handleAdd = () => {


### PR DESCRIPTION
## Summary
- synchronize local data with Firestore including remote events, hidden event ids, tag presets and todo preferences
- persist updates from all devices via new Firestore subscriptions
- guard token refresh in NextAuth when refresh token is missing
- update settings UI to react to storage changes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686c884cde788329806df615bda2518f