### PR TITLE
Fix refresh token handling and improve empty event UX

### DIFF
--- a/src/app/api/google-calendar/route.ts
+++ b/src/app/api/google-calendar/route.ts
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    if (session.error === 'RefreshAccessTokenError') {
+    if (session.error === 'RefreshAccessTokenError' || session.error === 'MissingRefreshToken') {
       return NextResponse.json<ApiResponse<null>>(
         {
           success: false,

--- a/src/hooks/useDashboardViewState.ts
+++ b/src/hooks/useDashboardViewState.ts
@@ -114,11 +114,11 @@ export function useDashboardViewState(): DashboardViewState {
   if (events.length === 0) {
     return {
       severity: 'info',
-      message: 'É necessário conectar pelo menos uma agenda (Google ou ICS).',
+      message: 'No events found. You can add local events or connect a calendar.',
       isLoading: false,
       canSignIn: false,
       canSignOut: true,
-      showEvents: false,
+      showEvents: true,
       events: [],
       handleSignIn,
       handleSignOut,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -25,7 +25,8 @@ function validateScopes(scope?: string) {
 async function refreshAccessToken(token: JWT) {
   try {
     if (!token.refreshToken) {
-      throw new Error('Missing refresh token');
+      console.error('Missing refresh token');
+      return { ...token, error: 'MissingRefreshToken' };
     }
     if (process.env.NODE_ENV === 'development') {
       console.log('Refreshing access token...');

--- a/src/widgets/EventTimeline/index.tsx
+++ b/src/widgets/EventTimeline/index.tsx
@@ -38,7 +38,7 @@ export function EventTimeline({
         })}
       >
         <Typography align="center" variant="body2">
-          É necessário conectar pelo menos uma agenda (Google ou ICS).
+          No events to display.
         </Typography>
       </Box>
     );


### PR DESCRIPTION
## Summary
- handle missing refresh token gracefully
- allow timeline and event list widgets to work without connected calendars
- update dashboard view messages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686c908849608329bb9d3e46cd113908