### PR TITLE
Add Supabase integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Smart Desk
 
-Smart Desk is a small dashboard built with Next.js and Material UI. It aggregates events from Google Calendar and custom ICS feeds and also lets you manage local tasks and reminders.
+Smart Desk is a small dashboard built with Next.js and Material UI. It aggregates events from Google Calendar and custom ICS feeds and also lets you manage personal tasks and reminders.
 
 ## Features
 
@@ -10,6 +10,7 @@ Smart Desk is a small dashboard built with Next.js and Material UI. It aggregate
 - Add, edit and remove local events
 - Trash bin for tasks, columns and local events with restore option
 - Optional audio alerts and time announcements
+- **Offline first data sync with Supabase**
 
 ## Getting Started
 
@@ -22,6 +23,42 @@ Open `http://localhost:3000` in your browser.
 
 Local settings are persisted using `localStorage`. To reset all data simply clear the browser storage.
 
+### Environment variables
+
+```
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+```
+
+## Database setup on Supabase
+
+Create `tasks` and `events` tables with row level security enabled and policies based on the `user_id` column. The columns used in the hooks are:
+
+### `tasks`
+- `id` uuid primary key
+- `user_id` uuid reference to auth.users
+- `title` text
+- `description` text
+- `tags` text[]
+- `column_id` text
+- `quantity` integer
+- `quantity_total` integer
+- timestamp columns (`created_at`, `updated_at`)
+
+### `events`
+- `id` uuid primary key
+- `user_id` uuid reference to auth.users
+- `start` timestamptz
+- `end` timestamptz
+- `title` text
+- `attendee_count` integer
+- `calendar` text
+- `aknowledged` boolean
+- timestamp columns (`created_at`, `updated_at`)
+
+Enable policies so that each logged in user can only read and write their own rows.
+
 ## Tests
 
 No automated tests are provided. Run `npm run lint` to check the code style.
@@ -29,3 +66,39 @@ No automated tests are provided. Run `npm run lint` to check the code style.
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+
+## Example usage
+
+```tsx
+import { useTasks, useCreateTask, useUpdateTask, useDeleteTask } from '@/hooks/useSupabaseTasks';
+import { useEvents, useCreateEvent } from '@/hooks/useSupabaseEvents';
+
+function Dashboard() {
+  const { data: tasks } = useTasks();
+  const createTask = useCreateTask();
+  const updateTask = useUpdateTask();
+  const deleteTask = useDeleteTask();
+
+  const { data: events } = useEvents();
+  const createEvent = useCreateEvent();
+
+  // Example: add a task
+  function handleAdd() {
+    createTask.mutate({ title: 'My task', tags: [], columnId: 'todo' });
+  }
+
+  // Example: mark task done
+  function handleDone(id: string) {
+    updateTask.mutate({ id, updates: { columnId: 'done' } });
+  }
+
+  // Example: delete a task
+  function handleDelete(id: string) {
+    deleteTask.mutate(id);
+  }
+
+  return null;
+}
+```
+
+The hooks cache data with React Query. When the network is offline the cached data is used automatically and changes are queued until the connection is restored.

--- a/src/hooks/useSupabaseEvents.ts
+++ b/src/hooks/useSupabaseEvents.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useSupabaseClient } from '@/lib/supabaseClient';
+import {
+  createEvent,
+  deleteEvent,
+  fetchEvents,
+  updateEvent,
+  type NewEvent,
+} from '@/services/supabaseEventsService';
+import type { IEvent } from '@/types/IEvent';
+
+export function useEvents() {
+  const supabase = useSupabaseClient();
+  return useQuery({
+    queryKey: ['events'],
+    queryFn: () => fetchEvents(supabase),
+  });
+}
+
+export function useCreateEvent() {
+  const supabase = useSupabaseClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: NewEvent) => createEvent(supabase, payload),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['events'] }),
+  });
+}
+
+export function useUpdateEvent() {
+  const supabase = useSupabaseClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: Partial<NewEvent> }) =>
+      updateEvent(supabase, id, updates),
+    onSuccess: (_res: IEvent) =>
+      queryClient.invalidateQueries({ queryKey: ['events'] }),
+  });
+}
+
+export function useDeleteEvent() {
+  const supabase = useSupabaseClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteEvent(supabase, id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['events'] }),
+  });
+}

--- a/src/hooks/useSupabaseTasks.ts
+++ b/src/hooks/useSupabaseTasks.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useSupabaseClient } from '@/lib/supabaseClient';
+import {
+  createTask,
+  deleteTask,
+  fetchTasks,
+  updateTask,
+  type NewTask,
+} from '@/services/supabaseTasksService';
+import type { TodoTask } from '@/widgets/TodoList/types';
+
+export function useTasks() {
+  const supabase = useSupabaseClient();
+  return useQuery({
+    queryKey: ['tasks'],
+    queryFn: () => fetchTasks(supabase),
+  });
+}
+
+export function useCreateTask() {
+  const supabase = useSupabaseClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: NewTask) => createTask(supabase, payload),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['tasks'] }),
+  });
+}
+
+export function useUpdateTask() {
+  const supabase = useSupabaseClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: Partial<NewTask> }) =>
+      updateTask(supabase, id, updates),
+    onSuccess: (_res: TodoTask) =>
+      queryClient.invalidateQueries({ queryKey: ['tasks'] }),
+  });
+}
+
+export function useDeleteTask() {
+  const supabase = useSupabaseClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteTask(supabase, id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['tasks'] }),
+  });
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,33 @@
+import { useEffect, useMemo } from 'react';
+import { createBrowserClient } from '@supabase/auth-helpers-nextjs';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { useSession } from 'next-auth/react';
+
+let client: SupabaseClient | null = null;
+
+function initClient() {
+  if (!client) {
+    client = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    );
+  }
+  return client;
+}
+
+export function useSupabaseClient(): SupabaseClient {
+  const { data: session } = useSession();
+
+  const supabase = useMemo(() => initClient(), []);
+
+  useEffect(() => {
+    // Attach NextAuth access token so RLS policies can identify the user
+    if (session?.accessToken) {
+      supabase.auth.setAuth(session.accessToken as string);
+    } else {
+      supabase.auth.signOut();
+    }
+  }, [session?.accessToken, supabase]);
+
+  return supabase;
+}

--- a/src/services/supabaseEventsService.ts
+++ b/src/services/supabaseEventsService.ts
@@ -1,0 +1,56 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { IEvent } from '@/types/IEvent';
+
+export interface NewEvent {
+  start: Date;
+  end: Date;
+  title: string;
+  attendeeCount?: number;
+  calendar?: string;
+  aknowledged?: boolean;
+}
+
+export async function fetchEvents(client: SupabaseClient): Promise<IEvent[]> {
+  const { data, error } = await client
+    .from('events')
+    .select('*')
+    .order('start', { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data ?? []) as IEvent[];
+}
+
+export async function createEvent(
+  client: SupabaseClient,
+  payload: NewEvent,
+): Promise<IEvent> {
+  const { data, error } = await client
+    .from('events')
+    .insert(payload)
+    .select()
+    .single();
+  if (error) throw new Error(error.message);
+  return data as IEvent;
+}
+
+export async function updateEvent(
+  client: SupabaseClient,
+  id: string,
+  updates: Partial<NewEvent>,
+): Promise<IEvent> {
+  const { data, error } = await client
+    .from('events')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single();
+  if (error) throw new Error(error.message);
+  return data as IEvent;
+}
+
+export async function deleteEvent(
+  client: SupabaseClient,
+  id: string,
+): Promise<void> {
+  const { error } = await client.from('events').delete().eq('id', id);
+  if (error) throw new Error(error.message);
+}

--- a/src/services/supabaseTasksService.ts
+++ b/src/services/supabaseTasksService.ts
@@ -1,0 +1,56 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { TodoTask } from '@/widgets/TodoList/types';
+
+export interface NewTask {
+  title: string;
+  description?: string;
+  tags: string[];
+  columnId: string;
+  quantity?: number;
+  quantityTotal?: number;
+}
+
+export async function fetchTasks(client: SupabaseClient): Promise<TodoTask[]> {
+  const { data, error } = await client
+    .from('tasks')
+    .select('*')
+    .order('created_at', { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data ?? []) as TodoTask[];
+}
+
+export async function createTask(
+  client: SupabaseClient,
+  payload: NewTask,
+): Promise<TodoTask> {
+  const { data, error } = await client
+    .from('tasks')
+    .insert(payload)
+    .select()
+    .single();
+  if (error) throw new Error(error.message);
+  return data as TodoTask;
+}
+
+export async function updateTask(
+  client: SupabaseClient,
+  id: string,
+  updates: Partial<NewTask>,
+): Promise<TodoTask> {
+  const { data, error } = await client
+    .from('tasks')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single();
+  if (error) throw new Error(error.message);
+  return data as TodoTask;
+}
+
+export async function deleteTask(
+  client: SupabaseClient,
+  id: string,
+): Promise<void> {
+  const { error } = await client.from('tasks').delete().eq('id', id);
+  if (error) throw new Error(error.message);
+}


### PR DESCRIPTION
## Summary
- integrate Supabase with hooks for tasks and events
- provide a Supabase client that reuses NextAuth session
- document Supabase environment and database setup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686dce2a2d948329b437374146d394e9