### PR TITLE
Add Supabase login helpers

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from 'react';
 import { SessionProvider } from 'next-auth/react';
 
 import { AppThemeProvider } from '@/providers/AppThemeProvider';
+import { SupabaseSyncProvider } from '@/providers/SupabaseSyncProvider';
 import { LocationProvider } from '@/providers/LocationProvider';
 import { ReactQueryProvider } from '@/providers/ReactQueryProvider';
 import { ServiceWorkerProvider } from '@/providers/ServiceWorkerProvider';
@@ -33,7 +34,9 @@ export default function RootLayout({ children }: RootLayoutProps) {
           <ServiceWorkerProvider>
             <LocationProvider>
               <ReactQueryProvider>
-                <AppThemeProvider>{children}</AppThemeProvider>
+                <SupabaseSyncProvider>
+                  <AppThemeProvider>{children}</AppThemeProvider>
+                </SupabaseSyncProvider>
               </ReactQueryProvider>
             </LocationProvider>
           </ServiceWorkerProvider>

--- a/src/hooks/useDashboardViewState.ts
+++ b/src/hooks/useDashboardViewState.ts
@@ -1,4 +1,8 @@
 import { signIn, signOut, useSession } from 'next-auth/react';
+import {
+  signInWithGoogle as supabaseSignIn,
+  signOutSupabase,
+} from '@/hooks/useSupabaseAuth';
 
 import { useEvents } from '@/hooks/useEvents';
 import { useEventStore } from '@/store/eventStore';
@@ -14,6 +18,7 @@ export function useDashboardViewState(): DashboardViewState {
     try {
       const res = await signIn('google', { redirect: false });
       if (res?.url) window.open(res.url, '_blank');
+      await supabaseSignIn();
     } catch (err) {
       displayError({ prefix: 'Error during sign in', error: err });
     }
@@ -22,6 +27,7 @@ export function useDashboardViewState(): DashboardViewState {
   const handleSignOut = async () => {
     try {
       await signOut();
+      await signOutSupabase();
     } catch (err) {
       displayError({ prefix: 'Error during sign out', error: err });
     }

--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -1,0 +1,34 @@
+import { getSupabaseClient } from '@/lib/supabaseClient';
+
+export async function signInWithGoogle(): Promise<void> {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: 'google',
+    options: { redirectTo: window.location.origin },
+  });
+  if (error) {
+    console.error('Supabase Google sign in failed', error);
+  } else if (data?.url) {
+    window.open(data.url, '_blank');
+  }
+}
+
+export async function signOutSupabase(): Promise<void> {
+  const supabase = getSupabaseClient();
+  const { error } = await supabase.auth.signOut();
+  if (error) {
+    console.error('Supabase sign out failed', error);
+  }
+}
+
+export async function isSupabaseLoggedIn(): Promise<boolean> {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase.auth.getSession();
+  if (error) {
+    console.error('Supabase session check failed', error);
+    return false;
+  }
+  const loggedIn = !!data.session;
+  console.debug('Supabase session present:', loggedIn);
+  return loggedIn;
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,8 +1,5 @@
-import { useEffect, useMemo } from 'react';
-
 import { createPagesBrowserClient } from '@supabase/auth-helpers-nextjs';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { useSession } from 'next-auth/react';
 
 let client: SupabaseClient | null = null;
 
@@ -12,27 +9,15 @@ function initClient(): SupabaseClient {
       supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
       supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     });
+    console.debug('Supabase client initialized');
   }
   return client;
 }
 
+export function getSupabaseClient(): SupabaseClient {
+  return initClient();
+}
+
 export function useSupabaseClient(): SupabaseClient {
-  const { data: session } = useSession();
-
-  const supabase = useMemo(() => initClient(), []);
-
-  useEffect(() => {
-    // Attach NextAuth access token so RLS policies can identify the user
-    if (session?.accessToken) {
-      // Use the global.auth.setSession method instead of deprecated setAuth
-      supabase.auth.setSession({
-        access_token: session.accessToken as string,
-        refresh_token: '',
-      });
-    } else {
-      supabase.auth.signOut();
-    }
-  }, [session?.accessToken, supabase]);
-
-  return supabase;
+  return initClient();
 }

--- a/src/providers/SupabaseSyncProvider.tsx
+++ b/src/providers/SupabaseSyncProvider.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+
+import { getSupabaseClient } from '@/lib/supabaseClient';
+import { isSupabaseLoggedIn } from '@/hooks/useSupabaseAuth';
+import { loadLocalEvents } from '@/utils/localEventsStorage';
+import { loadBoard } from '@/widgets/TodoList/boardStorage';
+import {
+  createEvent,
+  fetchEvents,
+} from '@/services/supabaseEventsService';
+import {
+  createTask,
+  fetchTasks,
+} from '@/services/supabaseTasksService';
+
+interface Props {
+  children: ReactNode;
+}
+
+export function SupabaseSyncProvider({ children }: Props) {
+  useEffect(() => {
+    async function sync() {
+      const supabase = getSupabaseClient();
+      const loggedIn = await isSupabaseLoggedIn();
+      if (!loggedIn) {
+        console.warn('Supabase sync skipped: no session');
+        return;
+      }
+      try {
+        const remoteEvents = await fetchEvents(supabase);
+        const eventIds = new Set(remoteEvents.map(e => e.id));
+        const localEvents = loadLocalEvents();
+        for (const ev of localEvents) {
+          if (!eventIds.has(ev.id)) {
+            console.debug('Sync: pushing local event', ev);
+            await createEvent(supabase, {
+              start: ev.start,
+              end: ev.end,
+              title: ev.title,
+              attendeeCount: ev.attendeeCount,
+              calendar: ev.calendar,
+              aknowledged: ev.aknowledged,
+            });
+          }
+        }
+
+        const remoteTasks = await fetchTasks(supabase);
+        const taskIds = new Set(remoteTasks.map(t => t.id));
+        const board = loadBoard();
+        for (const task of board.tasks) {
+          if (!taskIds.has(task.id)) {
+            console.debug('Sync: pushing local task', task);
+            await createTask(supabase, {
+              title: task.title,
+              description: task.description,
+              tags: task.tags,
+              columnId: task.columnId,
+              quantity: task.quantity,
+              quantityTotal: task.quantityTotal,
+            });
+          }
+        }
+      } catch (err) {
+        console.error('Supabase sync failed', err);
+      }
+    }
+
+    void sync();
+  }, []);
+
+  return <>{children}</>;
+}

--- a/src/services/supabaseEventsService.ts
+++ b/src/services/supabaseEventsService.ts
@@ -12,17 +12,27 @@ export interface NewEvent {
 }
 
 export async function fetchEvents(client: SupabaseClient): Promise<IEvent[]> {
+  console.debug('Supabase: fetching events');
   const { data, error } = await client
     .from('events')
     .select('*')
     .order('start', { ascending: true });
-  if (error) throw new Error(error.message);
+  if (error) {
+    console.error('Supabase: fetch events failed', error);
+    throw new Error(error.message);
+  }
+  console.debug('Supabase: fetched events', data);
   return (data ?? []) as IEvent[];
 }
 
 export async function createEvent(client: SupabaseClient, payload: NewEvent): Promise<IEvent> {
+  console.debug('Supabase: creating event', payload);
   const { data, error } = await client.from('events').insert(payload).select().single();
-  if (error) throw new Error(error.message);
+  if (error) {
+    console.error('Supabase: create event failed', error);
+    throw new Error(error.message);
+  }
+  console.debug('Supabase: created event', data);
   return data as IEvent;
 }
 
@@ -31,17 +41,27 @@ export async function updateEvent(
   id: string,
   updates: Partial<NewEvent>,
 ): Promise<IEvent> {
+  console.debug('Supabase: updating event', id, updates);
   const { data, error } = await client
     .from('events')
     .update(updates)
     .eq('id', id)
     .select()
     .single();
-  if (error) throw new Error(error.message);
+  if (error) {
+    console.error('Supabase: update event failed', error);
+    throw new Error(error.message);
+  }
+  console.debug('Supabase: updated event', data);
   return data as IEvent;
 }
 
 export async function deleteEvent(client: SupabaseClient, id: string): Promise<void> {
+  console.debug('Supabase: deleting event', id);
   const { error } = await client.from('events').delete().eq('id', id);
-  if (error) throw new Error(error.message);
+  if (error) {
+    console.error('Supabase: delete event failed', error);
+    throw new Error(error.message);
+  }
+  console.debug('Supabase: deleted event');
 }

--- a/src/services/supabaseTasksService.ts
+++ b/src/services/supabaseTasksService.ts
@@ -12,17 +12,27 @@ export interface NewTask {
 }
 
 export async function fetchTasks(client: SupabaseClient): Promise<TodoTask[]> {
+  console.debug('Supabase: fetching tasks');
   const { data, error } = await client
     .from('tasks')
     .select('*')
     .order('created_at', { ascending: true });
-  if (error) throw new Error(error.message);
+  if (error) {
+    console.error('Supabase: fetch tasks failed', error);
+    throw new Error(error.message);
+  }
+  console.debug('Supabase: fetched tasks', data);
   return (data ?? []) as TodoTask[];
 }
 
 export async function createTask(client: SupabaseClient, payload: NewTask): Promise<TodoTask> {
+  console.debug('Supabase: creating task', payload);
   const { data, error } = await client.from('tasks').insert(payload).select().single();
-  if (error) throw new Error(error.message);
+  if (error) {
+    console.error('Supabase: create task failed', error);
+    throw new Error(error.message);
+  }
+  console.debug('Supabase: created task', data);
   return data as TodoTask;
 }
 
@@ -31,12 +41,22 @@ export async function updateTask(
   id: string,
   updates: Partial<NewTask>,
 ): Promise<TodoTask> {
+  console.debug('Supabase: updating task', id, updates);
   const { data, error } = await client.from('tasks').update(updates).eq('id', id).select().single();
-  if (error) throw new Error(error.message);
+  if (error) {
+    console.error('Supabase: update task failed', error);
+    throw new Error(error.message);
+  }
+  console.debug('Supabase: updated task', data);
   return data as TodoTask;
 }
 
 export async function deleteTask(client: SupabaseClient, id: string): Promise<void> {
+  console.debug('Supabase: deleting task', id);
   const { error } = await client.from('tasks').delete().eq('id', id);
-  if (error) throw new Error(error.message);
+  if (error) {
+    console.error('Supabase: delete task failed', error);
+    throw new Error(error.message);
+  }
+  console.debug('Supabase: deleted task');
 }

--- a/src/utils/localEventsStorage.ts
+++ b/src/utils/localEventsStorage.ts
@@ -1,5 +1,7 @@
 import { IEvent } from '@/types/IEvent';
 import { getStoredFilters, setStoredFilters } from '@/utils/localStorageUtils';
+import { getSupabaseClient } from '@/lib/supabaseClient';
+import { createEvent, fetchEvents } from '@/services/supabaseEventsService';
 
 const STORAGE_KEY = 'local-events';
 
@@ -14,7 +16,31 @@ export function loadLocalEvents(): IEvent[] {
 export function saveLocalEvents(events: IEvent[]): void {
   try {
     setStoredFilters(STORAGE_KEY, events);
+    void syncWithSupabase(events);
   } catch {
     console.error('Could not save local events');
+  }
+}
+
+async function syncWithSupabase(events: IEvent[]): Promise<void> {
+  const supabase = getSupabaseClient();
+  try {
+    const remote = await fetchEvents(supabase);
+    const existing = new Set(remote.map(e => e.id));
+    for (const ev of events) {
+      if (!existing.has(ev.id)) {
+        console.debug('Sync local event to Supabase', ev);
+        await createEvent(supabase, {
+          start: ev.start,
+          end: ev.end,
+          title: ev.title,
+          attendeeCount: ev.attendeeCount,
+          calendar: ev.calendar,
+          aknowledged: ev.aknowledged,
+        });
+      }
+    }
+  } catch (err) {
+    console.error('Failed syncing events to Supabase', err);
   }
 }

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,17 @@
+# Supabase Setup
+
+This folder contains SQL scripts to create the tables used by Smart Desk.
+
+## Requirements
+
+Run these scripts in your Supabase project. They will create the `events` and `tasks` tables with row level security enabled.
+
+1. Open the SQL editor in the Supabase dashboard.
+2. Execute the scripts in `create_events_table.sql` and `create_tasks_table.sql`.
+3. Grant authenticated users access by enabling the included policies.
+
+Both scripts assume the `uuid-ossp` extension is available. If it is not, enable it with:
+
+```sql
+create extension if not exists "uuid-ossp";
+```

--- a/supabase/create_events_table.sql
+++ b/supabase/create_events_table.sql
@@ -1,0 +1,22 @@
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.events (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users not null,
+  start timestamptz not null,
+  "end" timestamptz not null,
+  title text not null,
+  attendee_count integer,
+  calendar text,
+  aknowledged boolean default false,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+alter table public.events enable row level security;
+
+create policy "Users can read events" on public.events
+  for select using (auth.uid() = user_id);
+
+create policy "Users can modify events" on public.events
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);

--- a/supabase/create_tasks_table.sql
+++ b/supabase/create_tasks_table.sql
@@ -1,0 +1,22 @@
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.tasks (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users not null,
+  title text not null,
+  description text,
+  tags text[] default '{}',
+  column_id text not null,
+  quantity integer,
+  quantity_total integer,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+alter table public.tasks enable row level security;
+
+create policy "Users can read tasks" on public.tasks
+  for select using (auth.uid() = user_id);
+
+create policy "Users can modify tasks" on public.tasks
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add helper functions to sign in/out of Supabase with Google
- wire Supabase login/out into dashboard view actions
- simplify Supabase client and add debug log
- skip sync when no Supabase session is present

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686dd8c72dd083299c9e00add5b53434