### PR TITLE
Fix Supabase login sync

### DIFF
--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -13,6 +13,17 @@ export async function signInWithGoogle(): Promise<void> {
   }
 }
 
+export async function signInWithIdToken(idToken: string): Promise<void> {
+  const supabase = getSupabaseClient();
+  const { error } = await supabase.auth.signInWithIdToken({
+    provider: 'google',
+    token: idToken,
+  });
+  if (error) {
+    console.error('Supabase ID token sign in failed', error);
+  }
+}
+
 export async function signOutSupabase(): Promise<void> {
   const supabase = getSupabaseClient();
   const { error } = await supabase.auth.signOut();


### PR DESCRIPTION
## Summary
- sync Supabase with Google session using ID token
- login effect ensures Supabase session once NextAuth finishes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686e786480b48329bd57c860afd07172