### PR TITLE
Fix Supabase sync for tasks and events

### DIFF
--- a/src/services/supabaseEventsService.ts
+++ b/src/services/supabaseEventsService.ts
@@ -3,6 +3,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import type { IEvent } from '@/types/IEvent';
 
 export interface NewEvent {
+  id?: string;
   start: Date;
   end: Date;
   title: string;

--- a/src/services/supabaseTasksService.ts
+++ b/src/services/supabaseTasksService.ts
@@ -3,6 +3,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import type { TodoTask } from '@/widgets/TodoList/types';
 
 export interface NewTask {
+  id?: string;
   title: string;
   description?: string;
   tags: string[];

--- a/src/utils/idUtils.ts
+++ b/src/utils/idUtils.ts
@@ -1,0 +1,8 @@
+export function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  const random = Math.random().toString(16).slice(2);
+  const timestamp = Date.now().toString(16);
+  return `${timestamp}-${random}`;
+}

--- a/src/widgets/EventList/index.tsx
+++ b/src/widgets/EventList/index.tsx
@@ -11,6 +11,7 @@ import {
   sortEventsByStart,
 } from '@/utils/eventUtils';
 import { EventListItem } from '@/widgets/EventList/EventListItem';
+import { generateId } from '@/utils/idUtils';
 
 interface EventListProps {
   events: IEvent[] | null;
@@ -48,7 +49,7 @@ export function EventList({ events }: EventListProps) {
             if (!text) return;
             const start = new Date();
             const end = new Date(start.getTime() + 60 * 60 * 1000);
-            addLocalEvent({ id: `local-${Date.now()}`, title: text, start, end });
+            addLocalEvent({ id: generateId(), title: text, start, end });
             setTitle('');
           }}
         >

--- a/src/widgets/LocalEventsManager/index.tsx
+++ b/src/widgets/LocalEventsManager/index.tsx
@@ -19,6 +19,7 @@ import { DateTime } from 'luxon';
 import { useEventStore } from '@/store/eventStore';
 import { showUndo } from '@/store/undoStore';
 import type { IEvent } from '@/types/IEvent';
+import { generateId } from '@/utils/idUtils';
 
 interface FormState {
   id?: string;
@@ -53,7 +54,7 @@ export function LocalEventsManager() {
   const handleSubmit = () => {
     if (!form.title.trim() || !form.start || !form.end) return;
     const event: IEvent = {
-      id: editingId ?? `local-${Date.now()}`,
+      id: editingId ?? generateId(),
       title: form.title.trim(),
       start: new Date(form.start),
       end: new Date(form.end),

--- a/src/widgets/TodoList/index.tsx
+++ b/src/widgets/TodoList/index.tsx
@@ -15,6 +15,7 @@ import { EditTaskModal } from '@/widgets/TodoList/EditTaskModal';
 import { TodoColumn } from '@/widgets/TodoList/TodoColumn';
 import { TrashDialog } from '@/widgets/TodoList/TrashDialog';
 import { BoardState, Column, TodoTask } from '@/widgets/TodoList/types';
+import { generateId } from '@/utils/idUtils';
 
 // Ensure drag and drop works on Safari PWAs
 import '@/lib/dragDropTouch';
@@ -167,7 +168,7 @@ export function TodoList({ events }: TodoListProps) {
 
   const handleAddTask = (columnId: string, title: string) => {
     const task: TodoTask = {
-      id: `todo-${Date.now()}`,
+      id: generateId(),
       title,
       tags: [],
       columnId,


### PR DESCRIPTION
## Summary
- ensure IDs are stable by generating UUIDs
- sync tasks/events with Supabase without duplicates
- import remote data when available

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686e7b5ba66c8329a7099e74986e4eaf