### PR TITLE
Fix Supabase sync and add columns support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ Ensure the Supabase project `Site URL` matches the domain you deploy to.
 
 ## Database setup on Supabase
 
-Create `tasks` and `events` tables with row level security enabled and policies based on the `user_id` column. The columns used in the hooks are:
-
+Create `tasks`, `columns` and `events` tables with row level security enabled and policies based on the `user_id` column. The columns used in the hooks are:
 ### `tasks`
 
 - `id` uuid primary key
@@ -60,9 +59,17 @@ Create `tasks` and `events` tables with row level security enabled and policies 
 - `title` text
 - `description` text
 - `tags` text[]
-- `column_id` text
+- `columnId` text
 - `quantity` integer
 - `quantity_total` integer
+- timestamp columns (`created_at`, `updated_at`)
+### `columns`
+
+- `id` uuid primary key
+- `user_id` uuid reference to auth.users
+- `title` text
+- `color` text
+- `position` integer
 - timestamp columns (`created_at`, `updated_at`)
 
 ### `events`

--- a/src/hooks/useSupabaseColumns.ts
+++ b/src/hooks/useSupabaseColumns.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { useSupabaseClient } from '@/lib/supabaseClient';
+import {
+  createColumn,
+  deleteColumn,
+  fetchColumns,
+  type NewColumn,
+  updateColumn,
+} from '@/services/supabaseColumnsService';
+import type { Column } from '@/widgets/TodoList/types';
+
+export function useColumns() {
+  const supabase = useSupabaseClient();
+  return useQuery({
+    queryKey: ['columns'],
+    queryFn: () => fetchColumns(supabase),
+  });
+}
+
+export function useCreateColumn() {
+  const supabase = useSupabaseClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: NewColumn) => createColumn(supabase, payload),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['columns'] }),
+  });
+}
+
+export function useUpdateColumn() {
+  const supabase = useSupabaseClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: Partial<NewColumn> }) =>
+      updateColumn(supabase, id, updates),
+    onSuccess: (_res: Column) => queryClient.invalidateQueries({ queryKey: ['columns'] }),
+  });
+}
+
+export function useDeleteColumn() {
+  const supabase = useSupabaseClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteColumn(supabase, id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['columns'] }),
+  });
+}

--- a/src/services/supabaseColumnsService.ts
+++ b/src/services/supabaseColumnsService.ts
@@ -1,0 +1,86 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { Column } from '@/widgets/TodoList/types';
+
+export interface NewColumn {
+  id?: string;
+  title: string;
+  color: string;
+  position?: number;
+}
+
+export async function fetchColumns(client: SupabaseClient): Promise<Column[]> {
+  console.debug('Supabase: fetching columns');
+  const { data, error } = await client
+    .from('columns')
+    .select('*')
+    .order('position', { ascending: true });
+  if (error) {
+    console.error('Supabase: fetch columns failed', error);
+    throw new Error(error.message);
+  }
+  console.debug('Supabase: fetched columns', data);
+  return (data ?? []) as Column[];
+}
+
+export async function createColumn(
+  client: SupabaseClient,
+  payload: NewColumn,
+): Promise<Column> {
+  console.debug('Supabase: creating column', payload);
+  const {
+    data: { user },
+    error: userError,
+  } = await client.auth.getUser();
+  if (userError || !user?.id) {
+    console.error('Supabase: unable to determine user', userError);
+    throw new Error('User not authenticated');
+  }
+
+  const insertPayload = { ...payload, user_id: user.id };
+
+  const { data, error } = await client
+    .from('columns')
+    .upsert(insertPayload, { onConflict: 'id' })
+    .select()
+    .single();
+  if (error) {
+    console.error('Supabase: create column failed', error);
+    throw new Error(error.message);
+  }
+  console.debug('Supabase: created column', data);
+  return data as Column;
+}
+
+export async function updateColumn(
+  client: SupabaseClient,
+  id: string,
+  updates: Partial<NewColumn>,
+): Promise<Column> {
+  console.debug('Supabase: updating column', id, updates);
+  const { data, error } = await client
+    .from('columns')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single();
+  if (error) {
+    console.error('Supabase: update column failed', error);
+    throw new Error(error.message);
+  }
+  console.debug('Supabase: updated column', data);
+  return data as Column;
+}
+
+export async function deleteColumn(
+  client: SupabaseClient,
+  id: string,
+): Promise<void> {
+  console.debug('Supabase: deleting column', id);
+  const { error } = await client.from('columns').delete().eq('id', id);
+  if (error) {
+    console.error('Supabase: delete column failed', error);
+    throw new Error(error.message);
+  }
+  console.debug('Supabase: deleted column');
+}

--- a/supabase/create_columns_table.sql
+++ b/supabase/create_columns_table.sql
@@ -1,0 +1,19 @@
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.columns (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users not null,
+  title text not null,
+  color text not null,
+  position integer,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+alter table public.columns enable row level security;
+
+create policy "Users can read columns" on public.columns
+  for select using (auth.uid() = user_id);
+
+create policy "Users can modify columns" on public.columns
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add database script for `columns` table
- add Supabase service and hooks for columns
- sync board columns and tasks with Supabase
- poll Supabase every minute to keep board data fresh
- document new table in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686e88c022748329aafc0c340a1f6729