### PR TITLE
feat: sync columns with slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ Create `tasks`, `columns` and `events` tables with row level security enabled an
 - `title` text
 - `description` text
 - `tags` text[]
-- `columnId` text
+- `columnId` text references `columns(id)`
 - `quantity` integer
 - `quantity_total` integer
 - timestamp columns (`created_at`, `updated_at`)
 ### `columns`
 
-- `id` uuid primary key
+- `id` text primary key
 - `user_id` uuid reference to auth.users
 - `title` text
 - `color` text
@@ -111,12 +111,12 @@ function Dashboard() {
 
   // Example: add a task
   function handleAdd() {
-    createTask.mutate({ title: 'My task', tags: [], columnId: 'todo' });
+    createTask.mutate({ title: 'My task', tags: [], columnSlug: 'todo' });
   }
 
   // Example: mark task done
   function handleDone(id: string) {
-    updateTask.mutate({ id, updates: { columnId: 'done' } });
+    updateTask.mutate({ id, updates: { columnSlug: 'done' } });
   }
 
   // Example: delete a task

--- a/src/providers/SupabaseSyncProvider.tsx
+++ b/src/providers/SupabaseSyncProvider.tsx
@@ -76,7 +76,7 @@ export function SupabaseSyncProvider({ children }: Props) {
               title: task.title,
               description: task.description,
               tags: task.tags,
-              columnId: task.columnId,
+              columnSlug: task.columnSlug,
               quantity: task.quantity,
               quantityTotal: task.quantityTotal,
             });

--- a/src/widgets/TodoList/AddTaskInput.tsx
+++ b/src/widgets/TodoList/AddTaskInput.tsx
@@ -3,15 +3,15 @@ import InputAdornment from '@mui/material/InputAdornment';
 import TextField from '@mui/material/TextField';
 
 interface AddTaskInputProps {
-  columnId: string;
+  columnSlug: string;
   columnColor: string;
-  onAdd: (columnId: string, title: string) => string;
+  onAdd: (columnSlug: string, title: string) => string;
   onStartEdit?: (id: string) => void;
 }
 
-export function AddTaskInput({ columnId, columnColor, onAdd, onStartEdit }: AddTaskInputProps) {
+export function AddTaskInput({ columnSlug, columnColor, onAdd, onStartEdit }: AddTaskInputProps) {
   const handleFocus = () => {
-    const id = onAdd(columnId, '');
+    const id = onAdd(columnSlug, '');
     onStartEdit?.(id);
   };
 

--- a/src/widgets/TodoList/TodoColumn.tsx
+++ b/src/widgets/TodoList/TodoColumn.tsx
@@ -17,11 +17,11 @@ interface TodoColumnProps {
   onRenameTask: (id: string, title: string) => void;
   onDeleteTask: (id: string) => void;
   onToggleDone: (id: string) => void;
-  onAddTask: (columnId: string, title: string) => string;
+  onAddTask: (columnSlug: string, title: string) => string;
   onDragStart: (e: React.DragEvent<HTMLDivElement>, id: string) => void;
   onDragOverTask: (e: React.DragEvent<HTMLDivElement>, id: string) => void;
-  onTaskColumnDragOver: (columnId: string) => void;
-  onDrop: (e: React.DragEvent<HTMLDivElement>, columnId: string) => void;
+  onTaskColumnDragOver: (columnSlug: string) => void;
+  onDrop: (e: React.DragEvent<HTMLDivElement>, columnSlug: string) => void;
   onColumnDragStart?: (e: React.DragEvent<HTMLDivElement>, id: string) => void;
   onColumnDragOver?: (e: React.DragEvent<HTMLDivElement>, overId: string) => void;
   onColumnDragEnd?: () => void;
@@ -145,7 +145,7 @@ export function TodoColumn({
 
       {!creatingId && showAddTaskInput && (
         <AddTaskInput
-          columnId={column.id}
+          columnSlug={column.id}
           columnColor={alpha(darken(column.color, 0.2), 0.15)}
           onAdd={handleAddTask}
         />

--- a/src/widgets/TodoList/TodoTaskCard.tsx
+++ b/src/widgets/TodoList/TodoTaskCard.tsx
@@ -151,7 +151,7 @@ export function TodoTaskCard({
                     maxWidth: '100%',
                     overflowWrap: 'anywhere',
                     whiteSpace: 'normal',
-                    textDecoration: task.columnId === 'done' ? 'line-through' : 'none',
+                  textDecoration: task.columnSlug === 'done' ? 'line-through' : 'none',
                   }}
                 >
                   {task.title}
@@ -201,7 +201,7 @@ export function TodoTaskCard({
                   </IconButton>
                 </Tooltip>
                 <Tooltip
-                  title={task.columnId === 'done' ? 'Uncheck task' : 'Check task'}
+                  title={task.columnSlug === 'done' ? 'Uncheck task' : 'Check task'}
                   enterTouchDelay={0}
                 >
                   <IconButton
@@ -218,7 +218,7 @@ export function TodoTaskCard({
                       borderBottomRightRadius: 1,
                     }}
                   >
-                    {task.columnId === 'done' ? (
+                    {task.columnSlug === 'done' ? (
                       <UndoIcon fontSize="inherit" />
                     ) : (
                       <CheckIcon fontSize="inherit" />

--- a/src/widgets/TodoList/TodoTrash.tsx
+++ b/src/widgets/TodoList/TodoTrash.tsx
@@ -55,19 +55,19 @@ function useTodoTrash() {
   /**
    * Restore a column and all its tasks
    */
-  function restoreColumn(columnId: string): void {
+  function restoreColumn(columnSlug: string): void {
     setBoard((prev: BoardState) => {
       // find the column in trash
-      const columnToRestore = prev.trash?.columns.find(c => c.id === columnId);
+      const columnToRestore = prev.trash?.columns.find(c => c.id === columnSlug);
       if (!columnToRestore) {
         return prev;
       }
 
       // pick up tasks that belonged to this column
-      const tasksInColumn: TodoTask[] = prev.trash!.tasks.filter(t => t.columnId === columnId);
+      const tasksInColumn: TodoTask[] = prev.trash!.tasks.filter(t => t.columnSlug === columnSlug);
       // filter out restored column and its tasks from trash
-      const updatedTrashColumns: Column[] = prev.trash!.columns.filter(c => c.id !== columnId);
-      const updatedTrashTasks: TodoTask[] = prev.trash!.tasks.filter(t => t.columnId !== columnId);
+      const updatedTrashColumns: Column[] = prev.trash!.columns.filter(c => c.id !== columnSlug);
+      const updatedTrashTasks: TodoTask[] = prev.trash!.tasks.filter(t => t.columnSlug !== columnSlug);
 
       return {
         ...prev,

--- a/src/widgets/TodoList/boardStorage.ts
+++ b/src/widgets/TodoList/boardStorage.ts
@@ -37,6 +37,18 @@ export function loadBoard(): BoardState {
       return DEFAULT_BOARD;
     }
     if (!board.trash) board.trash = { columns: [], tasks: [] };
+    // Migrate old columnId property if present
+    board.tasks = board.tasks.map(t => {
+      if ((t as any).columnId && !(t as any).columnSlug) {
+        (t as any).columnSlug = (t as any).columnId;
+        delete (t as any).columnId;
+      }
+      if ((t as any).prevColumnId && !(t as any).prevColumnSlug) {
+        (t as any).prevColumnSlug = (t as any).prevColumnId;
+        delete (t as any).prevColumnId;
+      }
+      return t;
+    });
     return board;
   } catch {
     return DEFAULT_BOARD;
@@ -71,7 +83,7 @@ async function syncTasksWithSupabase(board: BoardState): Promise<void> {
           title: task.title,
           description: task.description,
           tags: task.tags,
-          columnId: task.columnId,
+          columnSlug: task.columnSlug,
           quantity: task.quantity,
           quantityTotal: task.quantityTotal,
         });
@@ -85,7 +97,7 @@ async function syncTasksWithSupabase(board: BoardState): Promise<void> {
           title: task.title,
           description: task.description,
           tags: task.tags,
-          columnId: task.columnId,
+          columnSlug: task.columnSlug,
           quantity: task.quantity,
           quantityTotal: task.quantityTotal,
         });
@@ -111,7 +123,7 @@ function areTasksEqual(a: TodoTask, b: TodoTask): boolean {
   return (
     a.title === b.title &&
     a.description === b.description &&
-    a.columnId === b.columnId &&
+    a.columnSlug === b.columnSlug &&
     JSON.stringify(a.tags) === JSON.stringify(b.tags) &&
     a.quantity === b.quantity &&
     a.quantityTotal === b.quantityTotal

--- a/src/widgets/TodoList/index.tsx
+++ b/src/widgets/TodoList/index.tsx
@@ -93,7 +93,7 @@ export function TodoList({ events }: TodoListProps) {
           title: ev.title,
           description: undefined,
           tags: [],
-          columnId: 'todo',
+          columnSlug: 'todo',
         }));
       if (!additions.length) return prev;
       const updated = { ...prev, tasks: [...prev.tasks, ...additions] };
@@ -177,7 +177,7 @@ export function TodoList({ events }: TodoListProps) {
           title: ev.title,
           description: undefined,
           tags: [],
-          columnId: 'todo',
+          columnSlug: 'todo',
         }));
       if (!additions.length) return prev;
       const updated = { ...prev, tasks: [...prev.tasks, ...additions] };
@@ -192,17 +192,17 @@ export function TodoList({ events }: TodoListProps) {
     saveBoard(board);
   }, [board]);
 
-  const handleAddTask = (columnId: string, title: string) => {
+  const handleAddTask = (columnSlug: string, title: string) => {
     const task: TodoTask = {
       id: generateId(),
       title,
       tags: [],
-      columnId,
+      columnSlug,
     };
     setBoard(prev => {
       let columns = prev.columns;
-      if (!columns.some(c => c.id === columnId)) {
-        columns = [...columns, { id: columnId, title: 'Draft', color: '#616161' }];
+      if (!columns.some(c => c.id === columnSlug)) {
+        columns = [...columns, { id: columnSlug, title: 'Draft', color: '#616161' }];
       }
       return { ...prev, columns, tasks: [...prev.tasks, task] };
     });
@@ -261,31 +261,31 @@ export function TodoList({ events }: TodoListProps) {
       };
 
       // Only ensure 'done' column if moving to it
-      if (task.columnId !== 'done') {
+      if (task.columnSlug !== 'done') {
         ensureColumn('done', 'Done', '#2e7d32');
       }
 
       // Only ensure 'draft' column if we need to move back to it
       if (
-        task.columnId === 'done' &&
-        (!task.prevColumnId || !columns.some(c => c.id === task.prevColumnId))
+        task.columnSlug === 'done' &&
+        (!task.prevColumnSlug || !columns.some(c => c.id === task.prevColumnSlug))
       ) {
         ensureColumn('draft', 'Draft', '#616161');
       }
 
       const tasks = prev.tasks.map(t => {
         if (t.id !== id) return t;
-        if (t.columnId === 'done') {
+        if (t.columnSlug === 'done') {
           const target =
-            t.prevColumnId && columns.some(c => c.id === t.prevColumnId) ? t.prevColumnId : 'draft';
-          return { ...t, columnId: target, prevColumnId: undefined };
+            t.prevColumnSlug && columns.some(c => c.id === t.prevColumnSlug) ? t.prevColumnSlug : 'draft';
+          return { ...t, columnSlug: target, prevColumnSlug: undefined };
         }
 
         if (t.quantity && t.quantity > 1) {
           return { ...t, quantity: t.quantity - 1 };
         }
 
-        return { ...t, prevColumnId: t.columnId, columnId: 'done' };
+        return { ...t, prevColumnSlug: t.columnSlug, columnSlug: 'done' };
       });
 
       return needsColumnUpdate ? { ...prev, columns, tasks } : { ...prev, tasks };
@@ -322,10 +322,10 @@ export function TodoList({ events }: TodoListProps) {
     const id = columnModal.column.id;
     setBoard(prev => {
       const column = prev.columns.find(c => c.id === id);
-      const tasks = prev.tasks.filter(i => i.columnId === id);
+      const tasks = prev.tasks.filter(i => i.columnSlug === id);
       return {
         columns: prev.columns.filter(c => c.id !== id),
-        tasks: prev.tasks.filter(i => i.columnId !== id),
+        tasks: prev.tasks.filter(i => i.columnSlug !== id),
         trash: {
           columns: column ? [column, ...prev.trash.columns] : prev.trash.columns,
           tasks: [...tasks, ...prev.trash.tasks],
@@ -352,14 +352,14 @@ export function TodoList({ events }: TodoListProps) {
     setBoard(prev => {
       const column = prev.trash.columns.find(c => c.id === id);
       if (!column) return prev;
-      const tasks = prev.trash.tasks.filter(t => t.columnId === id);
+      const tasks = prev.trash.tasks.filter(t => t.columnSlug === id);
       return {
         ...prev,
         columns: [...prev.columns, column],
         tasks: [...prev.tasks, ...tasks],
         trash: {
           columns: prev.trash.columns.filter(c => c.id !== id),
-          tasks: prev.trash.tasks.filter(t => t.columnId !== id),
+          tasks: prev.trash.tasks.filter(t => t.columnSlug !== id),
         },
       };
     });
@@ -405,7 +405,7 @@ export function TodoList({ events }: TodoListProps) {
     setHoverTaskId(overId);
   };
 
-  const handleDrop = (event: React.DragEvent<HTMLDivElement>, columnId: string) => {
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>, columnSlug: string) => {
     event.preventDefault();
     const id = draggingId;
     setDraggingId(null);
@@ -420,15 +420,15 @@ export function TodoList({ events }: TodoListProps) {
       const [moved] = tasks.splice(from, 1);
       const to = overId
         ? tasks.findIndex(i => i.id === overId)
-        : tasks.reduce((idx, it, i) => (it.columnId === columnId ? i + 1 : idx), 0);
+        : tasks.reduce((idx, it, i) => (it.columnSlug === columnSlug ? i + 1 : idx), 0);
       const insertIndex = from < to ? to - 1 : to;
-      tasks.splice(insertIndex, 0, { ...moved, columnId });
+      tasks.splice(insertIndex, 0, { ...moved, columnSlug });
       return { ...prev, tasks };
     });
   };
 
   const renderColumn = (column: Column) => {
-    const tasks = board.tasks?.filter(i => i.columnId === column.id);
+    const tasks = board.tasks?.filter(i => i.columnSlug === column.id);
 
     return (
       <TodoColumn
@@ -469,7 +469,7 @@ export function TodoList({ events }: TodoListProps) {
         {board.columns.map(renderColumn)}
       </Stack>
       <EditTaskModal
-        column={board.columns.find(c => c.id === editingTask?.columnId) || null}
+        column={board.columns.find(c => c.id === editingTask?.columnSlug) || null}
         open={Boolean(editingTask)}
         task={editingTask}
         onSave={handleSaveTask}
@@ -501,7 +501,7 @@ export function TodoList({ events }: TodoListProps) {
             right: 16,
           }}
         >
-          <AddTaskInput columnId="draft" columnColor="#f0f0f0" onAdd={handleAddTask} />
+          <AddTaskInput columnSlug="draft" columnColor="#f0f0f0" onAdd={handleAddTask} />
         </Box>
       )}
 

--- a/src/widgets/TodoList/types.ts
+++ b/src/widgets/TodoList/types.ts
@@ -9,10 +9,10 @@ export interface TodoTask {
   title: string;
   description?: string;
   tags: string[];
-  columnId: string;
+  columnSlug: string;
   quantity?: number;
   quantityTotal?: number;
-  prevColumnId?: string;
+  prevColumnSlug?: string;
 }
 
 export interface BoardState {

--- a/supabase/create_columns_table.sql
+++ b/supabase/create_columns_table.sql
@@ -1,7 +1,7 @@
 create extension if not exists "uuid-ossp";
 
 create table if not exists public.columns (
-  id uuid primary key default uuid_generate_v4(),
+  id text primary key,
   user_id uuid references auth.users not null,
   title text not null,
   color text not null,

--- a/supabase/create_tasks_table.sql
+++ b/supabase/create_tasks_table.sql
@@ -6,7 +6,7 @@ create table if not exists public.tasks (
   title text not null,
   description text,
   tags text[] default '{}',
-  columnId text not null,
+  columnId text references columns(id) not null,
   quantity integer,
   quantityTotal integer,
   created_at timestamptz default now(),


### PR DESCRIPTION
## Summary
- make columns use text id and reference tasks table
- rename columnId usage to columnSlug in the frontend
- sync tasks/columns with new slug field
- add migration when loading board

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686e8ebadaec8329a98e65db6176a66f