### PR TITLE
Add error boundary around home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { useDashboardViewState } from '@/hooks/useDashboardViewState';
 import { useLocation } from '@/hooks/useLocation';
 import { useWeather } from '@/hooks/useWeather';
@@ -30,20 +31,22 @@ export default function Home() {
   );
 
   return (
-    <HomeView
-      dashboardViewState={dashboardViewState}
-      onAlertAcknowledge={setAlertAcknowledged}
-      audioEnabled={audioEnabled}
-      toggleAudioEnabled={toggleAudioEnabled}
-      isFirstRender={isFirstRender}
-      isMeetingAlertEnabled={isMeetingAlertEnabled}
-      onMeetingAlertToggle={toggleMeetingAlertEnabled}
-      isEventChangesAlertEnabled={isEventChangesAlertEnabled}
-      onEventChangesAlertToggle={toggleEventChangesAlertEnabled}
-      weather={weather}
-      weatherIsLoading={weatherIsLoading}
-      weatherIsError={weatherIsError}
-      weatherError={weatherError}
-    />
+    <ErrorBoundary>
+      <HomeView
+        dashboardViewState={dashboardViewState}
+        onAlertAcknowledge={setAlertAcknowledged}
+        audioEnabled={audioEnabled}
+        toggleAudioEnabled={toggleAudioEnabled}
+        isFirstRender={isFirstRender}
+        isMeetingAlertEnabled={isMeetingAlertEnabled}
+        onMeetingAlertToggle={toggleMeetingAlertEnabled}
+        isEventChangesAlertEnabled={isEventChangesAlertEnabled}
+        onEventChangesAlertToggle={toggleEventChangesAlertEnabled}
+        weather={weather}
+        weatherIsLoading={weatherIsLoading}
+        weatherIsError={weatherIsError}
+        weatherError={weatherError}
+      />
+    </ErrorBoundary>
   );
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,29 @@
+import { Component, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  readonly children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  errorMessage: string;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false, errorMessage: '' };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, errorMessage: error.message };
+  }
+
+  componentDidCatch(error: Error, info: unknown): void {
+    console.error('Unhandled error:', error, info);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return <pre>{this.state.errorMessage}</pre>;
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
- wrap the home page in an ErrorBoundary to catch client errors
- implement a reusable ErrorBoundary component

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68748c044f608329848e0d85db7332b0