### PR TITLE
Cache Supabase user id

### DIFF
--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -1,4 +1,6 @@
 import { getSupabaseClient } from '@/lib/supabaseClient';
+import { fetchUserId } from '@/services/supabase/userService';
+import { useUserStore } from '@/store/userStore';
 
 export async function signInWithGoogle(): Promise<void> {
   const supabase = getSupabaseClient();
@@ -21,7 +23,10 @@ export async function signInWithIdToken(idToken: string): Promise<void> {
   });
   if (error) {
     console.error('Supabase ID token sign in failed', error);
+    return;
   }
+
+  await fetchUserId(supabase);
 }
 
 export async function signOutSupabase(): Promise<void> {
@@ -29,7 +34,10 @@ export async function signOutSupabase(): Promise<void> {
   const { error } = await supabase.auth.signOut();
   if (error) {
     console.error('Supabase sign out failed', error);
+    return;
   }
+
+  useUserStore.getState().setUserId(null);
 }
 
 export async function isSupabaseLoggedIn(): Promise<boolean> {

--- a/src/services/supabase/columnsService.ts
+++ b/src/services/supabase/columnsService.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+import { fetchUserId } from '@/services/supabase/userService';
 import { Column } from '@/types/column';
 import { mapColumnToDB, mapDBToColumn } from '@/utils/databaseUtils';
 
@@ -18,17 +19,12 @@ export async function fetchColumns(client: SupabaseClient): Promise<Column[]> {
 }
 
 export async function upsertColumn(client: SupabaseClient, payload: Column): Promise<Column> {
-  const {
-    data: { user },
-    error: authError,
-  } = await client.auth.getUser();
-
-  if (authError || !user?.id) {
-    console.error('upsertColumn auth failed', authError);
+  const userId = await fetchUserId(client);
+  if (!userId) {
     throw new Error('User not authenticated');
   }
 
-  const row = mapColumnToDB(payload, user.id);
+  const row = mapColumnToDB(payload, userId);
 
   const { data, error } = await client
     .from('columns')

--- a/src/services/supabase/icsCalendarsService.ts
+++ b/src/services/supabase/icsCalendarsService.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+import { fetchUserId } from '@/services/supabase/userService';
 import { IcsCalendar } from '@/types/icsCalendar';
 import { mapDBToIcsCalendar, mapIcsCalendarToDB } from '@/utils/databaseUtils';
 
@@ -21,17 +22,12 @@ export async function upsertIcsCalendar(
   client: SupabaseClient,
   payload: IcsCalendar,
 ): Promise<IcsCalendar> {
-  const {
-    data: { user },
-    error: authError,
-  } = await client.auth.getUser();
-
-  if (authError || !user?.id) {
-    console.error('upsertIcsCalendar auth failed', authError);
+  const userId = await fetchUserId(client);
+  if (!userId) {
     throw new Error('User not authenticated');
   }
 
-  const row = mapIcsCalendarToDB(payload, user.id);
+  const row = mapIcsCalendarToDB(payload, userId);
 
   const { data, error } = await client
     .from('ics_calendars')

--- a/src/services/supabase/tasksService.ts
+++ b/src/services/supabase/tasksService.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+import { fetchUserId } from '@/services/supabase/userService';
 import { Task } from '@/types/task';
 import { mapDBToTask, mapTaskToDB } from '@/utils/databaseUtils';
 
@@ -18,17 +19,12 @@ export async function fetchTasks(client: SupabaseClient): Promise<Task[]> {
 }
 
 export async function upsertTask(client: SupabaseClient, payload: Task): Promise<Task> {
-  const {
-    data: { user },
-    error: authError,
-  } = await client.auth.getUser();
-
-  if (authError || !user?.id) {
-    console.error('upsertTask auth failed', authError);
+  const userId = await fetchUserId(client);
+  if (!userId) {
     throw new Error('User not authenticated');
   }
 
-  const row = mapTaskToDB(payload, user.id);
+  const row = mapTaskToDB(payload, userId);
 
   const { data, error } = await client
     .from('tasks')

--- a/src/services/supabase/userService.ts
+++ b/src/services/supabase/userService.ts
@@ -1,0 +1,21 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { useUserStore } from '@/store/userStore';
+
+export async function fetchUserId(client: SupabaseClient): Promise<string | null> {
+  const store = useUserStore.getState();
+  if (store.id) return store.id;
+
+  const {
+    data: { user },
+    error,
+  } = await client.auth.getUser();
+
+  if (error || !user?.id) {
+    console.error('fetchUserId failed', error);
+    return null;
+  }
+
+  store.setUserId(user.id);
+  return user.id;
+}

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+import { buildStorageKey } from '@/utils/localStorageUtils';
+
+interface UserState {
+  id: string | null;
+  setUserId: (id: string | null) => void;
+}
+
+export const useUserStore = create<UserState>()(
+  persist(
+    set => ({
+      id: null,
+      setUserId: id => set({ id }),
+    }),
+    {
+      name: buildStorageKey('user'),
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
- add `userStore` using zustand to persist Supabase user id
- cache the user id via `fetchUserId` helper
- load and clear cached user during sign-in/out
- use cached id in Supabase services to avoid repeated `getUser` calls

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68785c1004fc83299f31322afac54ed5