### PR TITLE
Add todo progress tracker

### DIFF
--- a/src/store/todoPrefsStore.ts
+++ b/src/store/todoPrefsStore.ts
@@ -7,9 +7,14 @@ interface TodoPrefsState {
   setView: (view: 'board' | 'list') => void;
   trashOpen: boolean;
   setTrashOpen: (open: boolean) => void;
+  hideDoneColumn: boolean;
+  setHideDoneColumn: (hide: boolean) => void;
 }
 
-type TodoPrefsData = Pick<TodoPrefsState, 'view' | 'trashOpen'>;
+type TodoPrefsData = Pick<
+  TodoPrefsState,
+  'view' | 'trashOpen' | 'hideDoneColumn'
+>;
 
 const STORAGE_KEY = 'todo-prefs';
 
@@ -19,6 +24,7 @@ function loadPrefs(): TodoPrefsData {
       getStoredFilters<TodoPrefsData>(STORAGE_KEY) ?? {
         view: 'board',
         trashOpen: false,
+        hideDoneColumn: false,
       }
     );
   } catch {
@@ -27,6 +33,8 @@ function loadPrefs(): TodoPrefsData {
       setView: () => {},
       trashOpen: false,
       setTrashOpen: () => {},
+      hideDoneColumn: false,
+      setHideDoneColumn: () => {},
     } as TodoPrefsState;
   }
 }
@@ -35,6 +43,7 @@ function persistPrefs(state: TodoPrefsState) {
   const dataToStore: TodoPrefsData = {
     view: state.view,
     trashOpen: state.trashOpen,
+    hideDoneColumn: state.hideDoneColumn,
   };
   setStoredFilters(STORAGE_KEY, dataToStore);
 }
@@ -50,6 +59,12 @@ export const useTodoPrefsStore = create<TodoPrefsState>(set => ({
   setTrashOpen: open =>
     set(state => {
       const next = { ...state, trashOpen: open };
+      return next;
+    }),
+  setHideDoneColumn: hide =>
+    set(state => {
+      const next = { ...state, hideDoneColumn: hide };
+      persistPrefs(next);
       return next;
     }),
 }));

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -23,6 +23,7 @@ import { TagPresets } from '@/widgets/Settings/TagPresets';
 import { TodoViewSettings } from '@/widgets/Settings/TodoViewSettings';
 import { SoundAlert } from '@/widgets/SoundAlert';
 import { TodoList } from '@/widgets/TodoList';
+import { TodoProgress } from '@/widgets/TodoProgress';
 
 interface HomeViewProps {
   dashboardViewState: DashboardViewState;
@@ -138,7 +139,10 @@ export function HomeView({
         alignItems={isMobile ? 'stretch' : 'flex-start'}
       >
         <TodoList />
-        <EventList events={events} key={`${now.toISOString()}-EventList`} />
+        <Stack spacing={2} flexGrow={1}>
+          <TodoProgress />
+          <EventList events={events} key={`${now.toISOString()}-EventList`} />
+        </Stack>
       </Stack>
 
       <EventAlert

--- a/src/widgets/TodoList/TodoColumn.tsx
+++ b/src/widgets/TodoList/TodoColumn.tsx
@@ -35,6 +35,7 @@ interface TodoColumnProps {
   draggingColumnId?: string | null;
   showAddTaskInput?: boolean;
   syncStatus: SyncStatus;
+  onHideColumn?: () => void;
 }
 
 export function TodoColumn({
@@ -60,6 +61,7 @@ export function TodoColumn({
   draggingColumnId,
   showAddTaskInput = true,
   syncStatus,
+  onHideColumn,
 }: TodoColumnProps) {
   const [creatingId, setCreatingId] = useState<string | null>(null);
   const [hideColumn, setHideColumn] = useState(false);
@@ -129,7 +131,13 @@ export function TodoColumn({
             <IconButton
               size="small"
               className="column-hide-btn"
-              onClick={() => setHideColumn(!hideColumn)}
+              onClick={() => {
+                if (onHideColumn) {
+                  onHideColumn();
+                } else {
+                  setHideColumn(!hideColumn);
+                }
+              }}
               sx={{
                 opacity: hideColumn ? 0.5 : 0.8,
                 color: hideColumn ? 'text.secondary' : column.color,

--- a/src/widgets/TodoList/index.tsx
+++ b/src/widgets/TodoList/index.tsx
@@ -5,6 +5,7 @@ import { Button, Stack } from '@mui/material';
 import { useResponsiveness } from '@/hooks/useResponsiveness';
 import { useBoardStore } from '@/store/board/store';
 import { useSyncStatusStore } from '@/store/syncStatus';
+import { useTodoPrefsStore } from '@/store/todoPrefsStore';
 import { Column } from '@/types/column';
 import { Task } from '@/types/task';
 import { getNewColumnPosition, isTaskEmpty } from '@/utils/boardHelpers';
@@ -43,7 +44,14 @@ export function TodoList() {
 
   const [editingTask, setEditingTask] = useState<Task | null>(null);
 
-  const columnsToRender = columns.filter(c => !c.trashed);
+  const hideDoneColumn = useTodoPrefsStore(state => state.hideDoneColumn);
+  const setHideDoneColumn = useTodoPrefsStore(state => state.setHideDoneColumn);
+
+  const columnsToRender = columns.filter(c => {
+    if (c.trashed) return false;
+    if (hideDoneColumn && c.title === 'Done') return false;
+    return true;
+  });
   const boardIsEmpty = columnsToRender.length === 0;
 
   // ── Column modal open/close ─────────────────────────────────────────────
@@ -265,6 +273,10 @@ export function TodoList() {
 
   const renderColumn = (column: Column) => {
     const colTasks = tasks.filter(t => t.columnId === column.id && !t.trashed);
+    const onHideColumn =
+      column.title === 'Done'
+        ? () => setHideDoneColumn(true)
+        : undefined;
     return (
       <TodoColumn
         key={column.id}
@@ -291,6 +303,7 @@ export function TodoList() {
         draggingColumnId={draggingColumnId}
         showAddTaskInput={!isMobile}
         syncStatus={syncStatus}
+        onHideColumn={onHideColumn}
       />
     );
   };

--- a/src/widgets/TodoProgress/index.tsx
+++ b/src/widgets/TodoProgress/index.tsx
@@ -1,0 +1,46 @@
+import { Button, LinearProgress, Stack, Typography } from '@mui/material';
+
+import { useBoardStore } from '@/store/board/store';
+import { useTodoPrefsStore } from '@/store/todoPrefsStore';
+
+export function TodoProgress() {
+  const tasks = useBoardStore(state => state.tasks);
+  const columns = useBoardStore(state => state.columns);
+  const hideDoneColumn = useTodoPrefsStore(state => state.hideDoneColumn);
+  const setHideDoneColumn = useTodoPrefsStore(state => state.setHideDoneColumn);
+
+  const doneColumn = columns.find(c => !c.trashed && c.title === 'Done');
+  const totalCount = tasks.filter(t => !t.trashed).length;
+  const doneCount = doneColumn
+    ? tasks.filter(t => !t.trashed && t.columnId === doneColumn.id).length
+    : 0;
+
+  const percentage = totalCount === 0 ? 0 : Math.round((doneCount / totalCount) * 100);
+
+  return (
+    <Stack spacing={1}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Typography variant="h3" color="primary">
+          Progress
+        </Typography>
+        {doneColumn && (
+          <Button
+            size="small"
+            onClick={() => setHideDoneColumn(!hideDoneColumn)}
+          >
+            {hideDoneColumn ? 'Show Done' : 'Hide Done'}
+          </Button>
+        )}
+      </Stack>
+      <LinearProgress
+        variant="determinate"
+        value={percentage}
+        sx={{ height: 10, borderRadius: 5 }}
+      />
+      <Typography variant="body2" textAlign="right">
+        {percentage}% done
+      </Typography>
+    </Stack>
+  );
+}
+


### PR DESCRIPTION
## Summary
- track percentage of completed tasks
- allow hiding and showing the "Done" column
- insert progress tracker above the event list

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68785bd3af308329a0bbe10eec7095a1