### PR TITLE
feat: quick add after saving todo

### DIFF
--- a/src/widgets/TodoList/TodoColumn.tsx
+++ b/src/widgets/TodoList/TodoColumn.tsx
@@ -76,6 +76,12 @@ export function TodoColumn({
 
   const finishCreate = () => setCreatingId(null);
 
+  const createNextTask = async () => {
+    if (column.id) {
+      await handleAddTask(column.id, '');
+    }
+  };
+
   return (
     <Box
       className="todo-column"
@@ -184,6 +190,7 @@ export function TodoColumn({
               onDragOver={onDragOverTask}
               startEditing={creatingId === task.id}
               onEditingEnd={finishCreate}
+              onCreateNext={createNextTask}
               syncStatus={syncStatus}
             />
           </div>

--- a/src/widgets/TodoList/TodoTaskCard.tsx
+++ b/src/widgets/TodoList/TodoTaskCard.tsx
@@ -25,6 +25,7 @@ interface TodoTaskCardProps {
   onDragOver: (e: DragEvent<HTMLDivElement>, id: string) => void;
   startEditing?: boolean;
   onEditingEnd?: () => void;
+  onCreateNext?: () => void;
   syncStatus?: SyncStatus;
 }
 
@@ -38,6 +39,7 @@ export function TodoTaskCard({
   onDragOver,
   startEditing = false,
   onEditingEnd,
+  onCreateNext,
   syncStatus,
 }: TodoTaskCardProps) {
   const [editing, setEditing] = useState(Boolean(startEditing));
@@ -152,6 +154,7 @@ export function TodoTaskCard({
                   if (e.key === 'Enter') {
                     e.stopPropagation();
                     finishEditing();
+                    onCreateNext?.();
                   }
                 }}
                 slotProps={{


### PR DESCRIPTION
## Summary
- add `onCreateNext` prop to `TodoTaskCard`
- create new task automatically after saving with Enter

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68793cd078a88329a0973e844f43b147