### PR TITLE
Add MUI navigation and task pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "openmeteo": "^1.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-router-dom": "^7.7.0",
         "react-text-to-speech": "^2.1.0",
         "zustand": "^5.0.5"
       },
@@ -5730,6 +5731,53 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
       "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
       "license": "MIT"
+    },
+    "node_modules/react-router": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.0.tgz",
+      "integrity": "sha512-3FUYSwlvB/5wRJVTL/aavqHmfUKe0+Xm9MllkYgGo9eDwNdkvwlJGjpPxono1kCycLt6AnDTgjmXvK3/B4QGuw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.7.0.tgz",
+      "integrity": "sha512-wwGS19VkNBkneVh9/YD0pK3IsjWxQUVMDD6drlG7eJpo1rXBtctBqDyBm/k+oKHRAm1x9XWT3JFC82QI9YOXXA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.7.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/react-text-to-speech": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "openmeteo": "^1.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-router-dom": "^7.7.0",
     "react-text-to-speech": "^2.1.0",
     "zustand": "^5.0.5"
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { SessionProvider } from 'next-auth/react';
 import { AppThemeProvider } from '@/providers/AppThemeProvider';
 import { LocationProvider } from '@/providers/LocationProvider';
 import { ReactQueryProvider } from '@/providers/ReactQueryProvider';
+import { RouterProvider } from '@/providers/RouterProvider';
 import { ServiceWorkerProvider } from '@/providers/ServiceWorkerProvider';
 import { SupabaseSyncProvider } from '@/providers/SupabaseSyncProvider';
 import { ZoomProvider } from '@/providers/ZoomProvider';
@@ -37,7 +38,9 @@ export default function RootLayout({ children }: RootLayoutProps) {
               <ReactQueryProvider>
                 <SupabaseSyncProvider>
                   <ZoomProvider>
-                    <AppThemeProvider>{children}</AppThemeProvider>
+                    <RouterProvider>
+                      <AppThemeProvider>{children}</AppThemeProvider>
+                    </RouterProvider>
                   </ZoomProvider>
                 </SupabaseSyncProvider>
               </ReactQueryProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,52 +1,7 @@
 'use client';
 
-import { ErrorBoundary } from '@/components/ErrorBoundary';
-import { useDashboardViewState } from '@/hooks/useDashboardViewState';
-import { useLocation } from '@/hooks/useLocation';
-import { useWeather } from '@/hooks/useWeather';
-import { useAudioStore } from '@/store/audioStore';
-import { useEventStore } from '@/store/eventStore';
-import { HomeView } from '@/views/HomeView';
+import { AppRoutes } from '@/routes/AppRoutes';
 
 export default function Home() {
-  const dashboardViewState = useDashboardViewState();
-
-  const { latitude, longitude } = useLocation();
-  const {
-    data: weather,
-    isLoading: weatherIsLoading,
-    isError: weatherIsError,
-    error: weatherError,
-  } = useWeather(latitude, longitude);
-
-  const setAlertAcknowledged = useEventStore(state => state.setAlertAcknowledged);
-  const audioEnabled = useAudioStore(state => state.audioEnabled);
-  const toggleAudioEnabled = useAudioStore(state => state.toggleAudioEnabled);
-  const isFirstRender = useAudioStore(state => state.isFirstRender);
-  const isMeetingAlertEnabled = useAudioStore(state => state.meetingAlertEnabled);
-  const toggleMeetingAlertEnabled = useAudioStore(state => state.toggleMeetingAlertEnabled);
-  const isEventChangesAlertEnabled = useAudioStore(state => state.eventChangesAlertEnabled);
-  const toggleEventChangesAlertEnabled = useAudioStore(
-    state => state.toggleEventChangesAlertEnabled,
-  );
-
-  return (
-    <ErrorBoundary>
-      <HomeView
-        dashboardViewState={dashboardViewState}
-        onAlertAcknowledge={setAlertAcknowledged}
-        audioEnabled={audioEnabled}
-        toggleAudioEnabled={toggleAudioEnabled}
-        isFirstRender={isFirstRender}
-        isMeetingAlertEnabled={isMeetingAlertEnabled}
-        onMeetingAlertToggle={toggleMeetingAlertEnabled}
-        isEventChangesAlertEnabled={isEventChangesAlertEnabled}
-        onEventChangesAlertToggle={toggleEventChangesAlertEnabled}
-        weather={weather}
-        weatherIsLoading={weatherIsLoading}
-        weatherIsError={weatherIsError}
-        weatherError={weatherError}
-      />
-    </ErrorBoundary>
-  );
+  return <AppRoutes />;
 }

--- a/src/navigation/BottomNav.tsx
+++ b/src/navigation/BottomNav.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useLocation as useRouterLocation, useNavigate } from 'react-router-dom';
+
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import DeleteIcon from '@mui/icons-material/Delete';
+import DraftsIcon from '@mui/icons-material/Drafts';
+import HomeIcon from '@mui/icons-material/Home';
+import ListAltIcon from '@mui/icons-material/ListAlt';
+import { BottomNavigation, BottomNavigationAction, Paper } from '@mui/material';
+
+export function BottomNav() {
+  const location = useRouterLocation();
+  const navigate = useNavigate();
+
+  const handleChange = (_: unknown, value: string) => navigate(value);
+
+  return (
+    <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }} elevation={3}>
+      <BottomNavigation value={location.pathname} onChange={handleChange} showLabels>
+        <BottomNavigationAction label="Home" value="/" icon={<HomeIcon />} />
+        <BottomNavigationAction label="Tasks" value="/tasks" icon={<ListAltIcon />} />
+        <BottomNavigationAction label="Matrix" value="/matrix" icon={<DashboardIcon />} />
+        <BottomNavigationAction label="Drafts" value="/drafts" icon={<DraftsIcon />} />
+        <BottomNavigationAction label="Trash" value="/trash" icon={<DeleteIcon />} />
+      </BottomNavigation>
+    </Paper>
+  );
+}

--- a/src/navigation/NavigationLayout.tsx
+++ b/src/navigation/NavigationLayout.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { Outlet } from 'react-router-dom';
+
+import { Box } from '@mui/material';
+
+import { useResponsiveness } from '@/hooks/useResponsiveness';
+import { BottomNav } from '@/navigation/BottomNav';
+import { SideDrawer } from '@/navigation/SideDrawer';
+
+interface NavigationLayoutProps {
+  readonly children?: ReactNode;
+}
+
+export function NavigationLayout(_: NavigationLayoutProps) {
+  const { isMobile } = useResponsiveness();
+
+  return (
+    <Box sx={{ display: 'flex', width: '100%' }}>
+      {!isMobile && <SideDrawer />}
+      <Box component="main" sx={{ flexGrow: 1, pb: isMobile ? 7 : 0 }}>
+        <Outlet />
+      </Box>
+      {isMobile && <BottomNav />}
+    </Box>
+  );
+}

--- a/src/navigation/SideDrawer.tsx
+++ b/src/navigation/SideDrawer.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Link as RouterLink, useLocation as useRouterLocation } from 'react-router-dom';
+
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import DeleteIcon from '@mui/icons-material/Delete';
+import DraftsIcon from '@mui/icons-material/Drafts';
+import HomeIcon from '@mui/icons-material/Home';
+import ListAltIcon from '@mui/icons-material/ListAlt';
+import { Divider, Drawer, List, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+
+const drawerWidth = 200;
+
+export function SideDrawer() {
+  const location = useRouterLocation();
+
+  return (
+    <Drawer variant="permanent" sx={{ width: drawerWidth, [`& .MuiDrawer-paper`]: { width: drawerWidth, boxSizing: 'border-box' } }}>
+      <List>
+        <ListItemButton component={RouterLink} to="/" selected={location.pathname === '/'}>
+          <ListItemIcon>
+            <HomeIcon />
+          </ListItemIcon>
+          <ListItemText primary="Home" />
+        </ListItemButton>
+        <ListItemButton component={RouterLink} to="/tasks" selected={location.pathname === '/tasks'}>
+          <ListItemIcon>
+            <ListAltIcon />
+          </ListItemIcon>
+          <ListItemText primary="All Tasks" />
+        </ListItemButton>
+        <ListItemButton component={RouterLink} to="/matrix" selected={location.pathname === '/matrix'}>
+          <ListItemIcon>
+            <DashboardIcon />
+          </ListItemIcon>
+          <ListItemText primary="Matrix" />
+        </ListItemButton>
+        <Divider />
+        <ListItemButton component={RouterLink} to="/drafts" selected={location.pathname === '/drafts'}>
+          <ListItemIcon>
+            <DraftsIcon />
+          </ListItemIcon>
+          <ListItemText primary="Drafts" />
+        </ListItemButton>
+        <ListItemButton component={RouterLink} to="/trash" selected={location.pathname === '/trash'}>
+          <ListItemIcon>
+            <DeleteIcon />
+          </ListItemIcon>
+          <ListItemText primary="Trash" />
+        </ListItemButton>
+      </List>
+    </Drawer>
+  );
+}

--- a/src/pages/AllTasksPage.tsx
+++ b/src/pages/AllTasksPage.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Box, Stack, Table, TableBody, TableCell, TableHead, TableRow, TextField, Typography } from '@mui/material';
+
+import { useResponsiveness } from '@/hooks/useResponsiveness';
+import { useBoardStore } from '@/store/board/store';
+import { TodoTaskCard } from '@/widgets/TodoList/TodoTaskCard';
+
+export function AllTasksPage() {
+  const tasks = useBoardStore(state => state.tasks);
+  const columns = useBoardStore(state => state.columns);
+  const { isMobile } = useResponsiveness();
+  const [search, setSearch] = useState('');
+
+  const filtered = tasks.filter(task => {
+    if (task.trashed) return false;
+    return task.title.toLowerCase().includes(search.toLowerCase());
+  });
+
+  if (isMobile) {
+    return (
+      <Stack spacing={1} p={1}>
+        <TextField
+          label="Search"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          variant="outlined"
+        />
+        {filtered.map(task => {
+          const column = columns.find(c => c.id === task.columnId);
+          if (!column) return null;
+          return (
+            <TodoTaskCard
+              key={task.id}
+              task={task}
+              column={column}
+              onOpen={() => {}}
+              onRename={() => {}}
+              onToggleDone={() => {}}
+              onDragStart={() => {}}
+              onDragOver={() => {}}
+            />
+          );
+        })}
+        {filtered.length === 0 && <Typography>No tasks found</Typography>}
+      </Stack>
+    );
+  }
+
+  return (
+    <Box p={2}>
+      <TextField
+        label="Search"
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+        variant="outlined"
+        sx={{ mb: 2 }}
+      />
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Title</TableCell>
+            <TableCell>Column</TableCell>
+            <TableCell align="center">Important</TableCell>
+            <TableCell align="center">Urgent</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {filtered.map(task => {
+            const column = columns.find(c => c.id === task.columnId);
+            return (
+              <TableRow key={task.id} hover>
+                <TableCell>{task.title}</TableCell>
+                <TableCell>{column?.title ?? '—'}</TableCell>
+                <TableCell align="center">{task.important ? '✓' : ''}</TableCell>
+                <TableCell align="center">{task.urgent ? '✓' : ''}</TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+      {filtered.length === 0 && <Typography>No tasks found</Typography>}
+    </Box>
+  );
+}

--- a/src/pages/DraftsPage.tsx
+++ b/src/pages/DraftsPage.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { Box, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+
+import { useResponsiveness } from '@/hooks/useResponsiveness';
+import { useBoardStore } from '@/store/board/store';
+import { TodoTaskCard } from '@/widgets/TodoList/TodoTaskCard';
+
+export function DraftsPage() {
+  const tasks = useBoardStore(state => state.tasks);
+  const columns = useBoardStore(state => state.columns);
+  const { isMobile } = useResponsiveness();
+
+  const draftColumn = columns.find(c => c.title === 'Draft' && !c.trashed);
+  const filtered = tasks.filter(t => !t.trashed && t.columnId === draftColumn?.id);
+
+  if (isMobile) {
+    return (
+      <Stack spacing={1} p={1}>
+        {filtered.map(task => (
+          <TodoTaskCard
+            key={task.id}
+            task={task}
+            column={draftColumn!}
+            onOpen={() => {}}
+            onRename={() => {}}
+            onToggleDone={() => {}}
+            onDragStart={() => {}}
+            onDragOver={() => {}}
+          />
+        ))}
+        {filtered.length === 0 && <Typography>No drafts</Typography>}
+      </Stack>
+    );
+  }
+
+  return (
+    <Box p={2}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Title</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {filtered.map(task => (
+            <TableRow key={task.id} hover>
+              <TableCell>{task.title}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {filtered.length === 0 && <Typography>No drafts</Typography>}
+    </Box>
+  );
+}

--- a/src/pages/EisenhowerMatrixPage.tsx
+++ b/src/pages/EisenhowerMatrixPage.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { Grid, Paper, Stack, Typography } from '@mui/material';
+
+import { useResponsiveness } from '@/hooks/useResponsiveness';
+import { useBoardStore } from '@/store/board/store';
+import { TodoTaskCard } from '@/widgets/TodoList/TodoTaskCard';
+
+export function EisenhowerMatrixPage() {
+  const tasks = useBoardStore(state => state.tasks);
+  const columns = useBoardStore(state => state.columns);
+  const { isMobile } = useResponsiveness();
+
+  const active = tasks.filter(t => !t.trashed);
+  const q1 = active.filter(t => t.important && t.urgent);
+  const q2 = active.filter(t => t.important && !t.urgent);
+  const q3 = active.filter(t => !t.important && t.urgent);
+  const q4 = active.filter(t => !t.important && !t.urgent);
+
+  const renderList = (list: typeof tasks) => (
+    <Stack spacing={1}>
+      {list.map(task => {
+        const column = columns.find(c => c.id === task.columnId);
+        if (!column) return null;
+        if (isMobile) {
+          return (
+            <TodoTaskCard
+              key={task.id}
+              task={task}
+              column={column}
+              onOpen={() => {}}
+              onRename={() => {}}
+              onToggleDone={() => {}}
+              onDragStart={() => {}}
+              onDragOver={() => {}}
+            />
+          );
+        }
+        return <Typography key={task.id}>• {task.title}</Typography>;
+      })}
+      {list.length === 0 && <Typography>No tasks</Typography>}
+    </Stack>
+  );
+
+  if (isMobile) {
+    return (
+      <Stack p={1} spacing={2}>
+        <Typography variant="h3">Important & Urgent</Typography>
+        {renderList(q1)}
+        <Typography variant="h3">Important & Not Urgent</Typography>
+        {renderList(q2)}
+        <Typography variant="h3">Not Important & Urgent</Typography>
+        {renderList(q3)}
+        <Typography variant="h3">Not Important & Not Urgent</Typography>
+        {renderList(q4)}
+      </Stack>
+    );
+  }
+
+  return (
+    <Grid container spacing={2} p={2}>
+      <Grid item xs={6}>
+        <Paper sx={{ p: 1 }}>
+          <Typography variant="h4" gutterBottom>
+            Important & Urgent
+          </Typography>
+          {renderList(q1)}
+        </Paper>
+      </Grid>
+      <Grid item xs={6}>
+        <Paper sx={{ p: 1 }}>
+          <Typography variant="h4" gutterBottom>
+            Important & Not Urgent
+          </Typography>
+          {renderList(q2)}
+        </Paper>
+      </Grid>
+      <Grid item xs={6}>
+        <Paper sx={{ p: 1 }}>
+          <Typography variant="h4" gutterBottom>
+            Not Important & Urgent
+          </Typography>
+          {renderList(q3)}
+        </Paper>
+      </Grid>
+      <Grid item xs={6}>
+        <Paper sx={{ p: 1 }}>
+          <Typography variant="h4" gutterBottom>
+            Not Important & Not Urgent
+          </Typography>
+          {renderList(q4)}
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { useDashboardViewState } from '@/hooks/useDashboardViewState';
+import { useLocation } from '@/hooks/useLocation';
+import { useWeather } from '@/hooks/useWeather';
+import { useAudioStore } from '@/store/audioStore';
+import { useEventStore } from '@/store/eventStore';
+import { HomeView } from '@/views/HomeView';
+
+export function HomePage() {
+  const dashboardViewState = useDashboardViewState();
+
+  const { latitude, longitude } = useLocation();
+  const {
+    data: weather,
+    isLoading: weatherIsLoading,
+    isError: weatherIsError,
+    error: weatherError,
+  } = useWeather(latitude, longitude);
+
+  const setAlertAcknowledged = useEventStore(state => state.setAlertAcknowledged);
+  const audioEnabled = useAudioStore(state => state.audioEnabled);
+  const toggleAudioEnabled = useAudioStore(state => state.toggleAudioEnabled);
+  const isFirstRender = useAudioStore(state => state.isFirstRender);
+  const isMeetingAlertEnabled = useAudioStore(state => state.meetingAlertEnabled);
+  const toggleMeetingAlertEnabled = useAudioStore(state => state.toggleMeetingAlertEnabled);
+  const isEventChangesAlertEnabled = useAudioStore(state => state.eventChangesAlertEnabled);
+  const toggleEventChangesAlertEnabled = useAudioStore(
+    state => state.toggleEventChangesAlertEnabled,
+  );
+
+  return (
+    <ErrorBoundary>
+      <HomeView
+        dashboardViewState={dashboardViewState}
+        onAlertAcknowledge={setAlertAcknowledged}
+        audioEnabled={audioEnabled}
+        toggleAudioEnabled={toggleAudioEnabled}
+        isFirstRender={isFirstRender}
+        isMeetingAlertEnabled={isMeetingAlertEnabled}
+        onMeetingAlertToggle={toggleMeetingAlertEnabled}
+        isEventChangesAlertEnabled={isEventChangesAlertEnabled}
+        onEventChangesAlertToggle={toggleEventChangesAlertEnabled}
+        weather={weather}
+        weatherIsLoading={weatherIsLoading}
+        weatherIsError={weatherIsError}
+        weatherError={weatherError}
+      />
+    </ErrorBoundary>
+  );
+}

--- a/src/pages/TrashPage.tsx
+++ b/src/pages/TrashPage.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import RestoreIcon from '@mui/icons-material/RestoreFromTrash';
+import { Box, IconButton, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+
+import { useResponsiveness } from '@/hooks/useResponsiveness';
+import { useBoardStore } from '@/store/board/store';
+import { TodoTaskCard } from '@/widgets/TodoList/TodoTaskCard';
+
+export function TrashPage() {
+  const tasks = useBoardStore(state => state.tasks);
+  const updateTask = useBoardStore(state => state.updateTask);
+  const columns = useBoardStore(state => state.columns);
+  const { isMobile } = useResponsiveness();
+
+  const trashed = tasks.filter(t => t.trashed);
+
+  const handleRestore = async (id: string) => {
+    await updateTask({ id, trashed: false, updatedAt: new Date() });
+  };
+
+  if (isMobile) {
+    return (
+      <Stack spacing={1} p={1}>
+        {trashed.map(task => {
+          const column = columns.find(c => c.id === task.columnId) ?? columns[0];
+          return (
+            <Box key={task.id} position="relative">
+              <TodoTaskCard
+                task={task}
+                column={column}
+                onOpen={() => {}}
+                onRename={() => {}}
+                onToggleDone={() => {}}
+                onDragStart={() => {}}
+                onDragOver={() => {}}
+              />
+              <IconButton
+                aria-label="restore"
+                onClick={() => handleRestore(task.id)}
+                sx={{ position: 'absolute', top: 4, right: 4 }}
+              >
+                <RestoreIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          );
+        })}
+        {trashed.length === 0 && <Typography>Trash is empty</Typography>}
+      </Stack>
+    );
+  }
+
+  return (
+    <Box p={2}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Title</TableCell>
+            <TableCell>Column</TableCell>
+            <TableCell align="right">Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {trashed.map(task => {
+            const column = columns.find(c => c.id === task.columnId);
+            return (
+              <TableRow key={task.id} hover>
+                <TableCell>{task.title}</TableCell>
+                <TableCell>{column?.title ?? '—'}</TableCell>
+                <TableCell align="right">
+                  <IconButton aria-label="restore" onClick={() => handleRestore(task.id)}>
+                    <RestoreIcon fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+      {trashed.length === 0 && <Typography>Trash is empty</Typography>}
+    </Box>
+  );
+}

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+
+interface RouterProviderProps {
+  readonly children: ReactNode;
+}
+
+export function RouterProvider({ children }: RouterProviderProps) {
+  return <BrowserRouter>{children}</BrowserRouter>;
+}

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Route, Routes } from 'react-router-dom';
+
+import { NavigationLayout } from '@/navigation/NavigationLayout';
+import { AllTasksPage } from '@/pages/AllTasksPage';
+import { DraftsPage } from '@/pages/DraftsPage';
+import { EisenhowerMatrixPage } from '@/pages/EisenhowerMatrixPage';
+import { HomePage } from '@/pages/HomePage';
+import { TrashPage } from '@/pages/TrashPage';
+
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route element={<NavigationLayout />}>
+        <Route index element={<HomePage />} />
+        <Route path="tasks" element={<AllTasksPage />} />
+        <Route path="matrix" element={<EisenhowerMatrixPage />} />
+        <Route path="drafts" element={<DraftsPage />} />
+        <Route path="trash" element={<TrashPage />} />
+      </Route>
+    </Routes>
+  );
+}


### PR DESCRIPTION
## Summary
- add BrowserRouter provider
- create responsive navigation drawer and bottom bar
- add pages for Home, All Tasks, Eisenhower Matrix, Drafts and Trash
- wire routes with React Router

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68794caffa5c83298fe3fd8f81d9419d