### PR TITLE
feat: enable matrix task drag and drop

### DIFF
--- a/src/app/matrix/page.tsx
+++ b/src/app/matrix/page.tsx
@@ -13,6 +13,7 @@ import type { Task } from '@/types/task';
 
 export default function EisenhowerMatrixPage() {
   const updateTask = useBoardStore(s => s.updateTask);
+  const tasks = useBoardStore(s => s.tasks);
   const { activeTasks } = useTasks();
 
   const [draggingId, setDraggingId] = useState<string | null>(null);
@@ -22,14 +23,32 @@ export default function EisenhowerMatrixPage() {
     setDraggingId(task.id);
   };
 
+  const handleDragEnd = () => {
+    setDraggingId(null);
+  };
+
   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
   };
 
   const handleDrop =
-    (important: boolean, urgent: boolean) => async (e: React.DragEvent<HTMLDivElement>) => {
+    (important: boolean, urgent: boolean) => async (
+      e: React.DragEvent<HTMLDivElement>,
+    ) => {
       e.preventDefault();
       if (!draggingId) return;
+
+      const task = tasks.find(t => t.id === draggingId);
+      if (!task) {
+        setDraggingId(null);
+        return;
+      }
+
+      if (task.important === important && task.urgent === urgent) {
+        setDraggingId(null);
+        return;
+      }
+
       await updateTask({
         id: draggingId,
         important,
@@ -45,7 +64,7 @@ export default function EisenhowerMatrixPage() {
       description="Decide what matters, not just what screams for attention"
     >
       <Stack display="grid" gridTemplateColumns="1fr 1fr" gap={2}>
-        {eisenhowerQuadrants.map(({ title, color, important, urgent, signals, examples }) => {
+        {eisenhowerQuadrants.map(({ title, color, important, urgent, signals, examples, action }) => {
           const tasks = activeTasks.filter(t => t.important === important && t.urgent === urgent);
 
           return (
@@ -55,11 +74,14 @@ export default function EisenhowerMatrixPage() {
               tasks={tasks}
               signals={signals}
               examples={examples}
+              action={action}
               quadrantColor={color}
               important={important}
               urgent={urgent}
+              isDragInProgress={!!draggingId}
               onTaskDragStart={handleDragStart}
               onTaskDragOver={handleDragOver}
+              onTaskDragEnd={handleDragEnd}
               onTaskDrop={handleDrop(important, urgent)}
             />
           );

--- a/src/components/EisenhowerQuadrant.tsx
+++ b/src/components/EisenhowerQuadrant.tsx
@@ -11,25 +11,31 @@ import type { Task } from '@/types/task';
 
 interface EisenhowerQuadrantProps {
   title: string;
+  action: string;
   tasks: Task[];
   quadrantColor: string; // CSS color string
   important: boolean;
   urgent: boolean;
   signals: string[];
   examples: string[];
+  isDragInProgress: boolean;
   onTaskDragStart: (task: Task, e: DragEvent<HTMLDivElement>) => void;
   onTaskDragOver: (e: DragEvent<HTMLDivElement>) => void;
+  onTaskDragEnd: () => void;
   onTaskDrop: (e: DragEvent<HTMLDivElement>) => void;
 }
 
 export function EisenhowerQuadrant({
   title,
+  action,
   tasks,
   quadrantColor,
   important,
   urgent,
+  isDragInProgress,
   onTaskDragStart,
   onTaskDragOver,
+  onTaskDragEnd,
   onTaskDrop,
 }: EisenhowerQuadrantProps) {
   const theme = useTheme();
@@ -65,35 +71,60 @@ export function EisenhowerQuadrant({
         p: 2,
         boxShadow: 1,
         borderRadius: theme.shape.borderRadius,
+        border: isDragInProgress ? `2px dashed ${quadrantColor}` : undefined,
       }}
     >
-      <Stack direction="row" alignItems="center" gap={1} mb={2}>
+      <Stack direction="row" alignItems="center" gap={1} mb={1}>
         {hasIcon && <Icon color={iconColor} fontSize={iconSize} />}
 
         <Typography variant="h6" sx={{ color: quadrantColor }}>
           {title}
         </Typography>
       </Stack>
+      <Typography variant="subtitle2" color="textSecondary" mb={2}>
+        {action}
+      </Typography>
 
-      <Stack direction="row" flexWrap="wrap" gap={1}>
-        {tasks.length === 0 ? (
-          <Typography variant="body2" color="textSecondary">
-            No tasks found
-          </Typography>
-        ) : (
-          tasks.map(task => (
-            <Stack
-              key={task.id}
-              gap={1}
-              draggable
-              onDragStart={e => onTaskDragStart(task, e)}
-              onDragOver={onTaskDragOver}
-            >
-              <TaskCard task={task} color={quadrantColor} eisenhowerIcons={false} />
-            </Stack>
-          ))
-        )}
-      </Stack>
+      {isDragInProgress ? (
+        <Stack gap={1}>
+          <Typography variant="subtitle2">Signals</Typography>
+          <Stack component="ul" gap={0.5} sx={{ pl: 2, listStyle: 'disc' }}>
+            {signals.map(signal => (
+              <Typography component="li" variant="body2" key={signal}>
+                {signal}
+              </Typography>
+            ))}
+          </Stack>
+          <Typography variant="subtitle2">Examples</Typography>
+          <Stack component="ul" gap={0.5} sx={{ pl: 2, listStyle: 'disc' }}>
+            {examples.map(example => (
+              <Typography component="li" variant="body2" key={example}>
+                {example}
+              </Typography>
+            ))}
+          </Stack>
+        </Stack>
+      ) : (
+        <Stack direction="row" flexWrap="wrap" gap={1}>
+          {tasks.length === 0 ? (
+            <Typography variant="body2" color="textSecondary">
+              No tasks found
+            </Typography>
+          ) : (
+            tasks.map(task => (
+              <TaskCard
+                key={task.id}
+                task={task}
+                color={quadrantColor}
+                eisenhowerIcons={false}
+                onTaskDragStart={onTaskDragStart}
+                onTaskDragOver={onTaskDragOver}
+                onTaskDragEnd={onTaskDragEnd}
+              />
+            ))
+          )}
+        </Stack>
+      )}
     </Paper>
   );
 }

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -43,6 +43,7 @@ interface TaskCardProps extends BoxProps {
   onFinishEditing?: () => void;
   onTaskDragStart?: (id: string, e: DragEvent<HTMLDivElement>) => void;
   onTaskDragOver?: (id: string, e: DragEvent<HTMLDivElement>) => void;
+  onTaskDragEnd?: (id: string, e: DragEvent<HTMLDivElement>) => void;
 }
 
 export function TaskCard({
@@ -53,6 +54,7 @@ export function TaskCard({
   onFinishEditing,
   onTaskDragStart,
   onTaskDragOver,
+  onTaskDragEnd,
   ...props
 }: TaskCardProps) {
   const { isMobile } = useResponsiveness();
@@ -73,6 +75,7 @@ export function TaskCard({
   const [isEditModalOpen, setEditModalOpen] = useState(false);
   const [isToggleConfirmOpen, setToggleConfirmOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setDragging] = useState(false);
 
   // sync edit mode if parent toggles it
   useEffect(() => {
@@ -92,6 +95,7 @@ export function TaskCard({
   const handleDragStart = useCallback(
     (e: DragEvent<HTMLDivElement>) => {
       e.stopPropagation();
+      setDragging(true);
       onTaskDragStart?.(task.id, e);
     },
     [onTaskDragStart, task.id],
@@ -103,6 +107,14 @@ export function TaskCard({
       onTaskDragOver?.(task.id, e);
     },
     [onTaskDragOver, task.id],
+  );
+
+  const handleDragEnd = useCallback(
+    (e: DragEvent<HTMLDivElement>) => {
+      setDragging(false);
+      onTaskDragEnd?.(task.id, e);
+    },
+    [onTaskDragEnd, task.id],
   );
 
   // common save logic for edits
@@ -252,11 +264,13 @@ export function TaskCard({
         color={color}
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}
+        onDragEnd={handleDragEnd}
         draggable={!isEditing && !isMobile}
         minHeight={cardMinHeight}
         gap={itemsGap}
         paddingX={isMobile ? 2 : 1.5}
         paddingY={1.5}
+        sx={{ cursor: isDragging ? 'grabbing' : undefined }}
         {...props}
       >
         {shouldShowIcons && (


### PR DESCRIPTION
## Summary
- enable drag'n'drop in Eisenhower matrix
- add quadrant help text while dragging
- show suggested action on each quadrant
- display grabbing cursor while moving a task

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c3b510ad0832981118d0d6a198217