### PR TITLE
feat: list hidden columns on board

### DIFF
--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -15,6 +15,7 @@ import { Clock } from '@/widgets/Clock';
 import { EventAlert } from '@/widgets/EventAlert';
 import { EventList } from '@/widgets/EventList';
 import { EventTimeline } from '@/widgets/EventTimeline';
+import { HiddenColumnsList } from '@/widgets/HiddenColumnsList';
 import { TodoList } from '@/widgets/TodoList';
 import { TodoProgress } from '@/widgets/TodoProgress';
 
@@ -64,6 +65,7 @@ export default function BoardPage() {
           <Stack spacing={2}>
             <TodoProgress alignSelf="flex-end" />
             <EventList events={events} key={`${now.toISOString()}-EventList`} />
+            <HiddenColumnsList />
           </Stack>
         </Stack>
       </Stack>

--- a/src/store/todoPrefsStore.ts
+++ b/src/store/todoPrefsStore.ts
@@ -9,9 +9,14 @@ interface TodoPrefsState {
   setTrashOpen: (open: boolean) => void;
   hideDoneColumn: boolean;
   setHideDoneColumn: (hide: boolean) => void;
+  hiddenColumnIds: string[];
+  toggleHiddenColumn: (id: string) => void;
 }
 
-type TodoPrefsData = Pick<TodoPrefsState, 'view' | 'trashOpen' | 'hideDoneColumn'>;
+type TodoPrefsData = Pick<
+  TodoPrefsState,
+  'view' | 'trashOpen' | 'hideDoneColumn' | 'hiddenColumnIds'
+>;
 
 const STORAGE_KEY = 'todo-prefs';
 
@@ -22,6 +27,7 @@ function loadPrefs(): TodoPrefsData {
         view: 'board',
         trashOpen: false,
         hideDoneColumn: true,
+        hiddenColumnIds: [],
       }
     );
   } catch {
@@ -32,6 +38,8 @@ function loadPrefs(): TodoPrefsData {
       setTrashOpen: () => {},
       hideDoneColumn: false,
       setHideDoneColumn: () => {},
+      hiddenColumnIds: [],
+      toggleHiddenColumn: () => {},
     } as TodoPrefsState;
   }
 }
@@ -41,6 +49,7 @@ function persistPrefs(state: TodoPrefsState) {
     view: state.view,
     trashOpen: state.trashOpen,
     hideDoneColumn: state.hideDoneColumn,
+    hiddenColumnIds: state.hiddenColumnIds,
   };
   setStoredFilters(STORAGE_KEY, dataToStore);
 }
@@ -61,6 +70,16 @@ export const useTodoPrefsStore = create<TodoPrefsState>(set => ({
   setHideDoneColumn: hide =>
     set(state => {
       const next = { ...state, hideDoneColumn: hide };
+      persistPrefs(next);
+      return next;
+    }),
+  toggleHiddenColumn: id =>
+    set(state => {
+      const exists = state.hiddenColumnIds.includes(id);
+      const nextIds = exists
+        ? state.hiddenColumnIds.filter(cid => cid !== id)
+        : [...state.hiddenColumnIds, id];
+      const next = { ...state, hiddenColumnIds: nextIds };
       persistPrefs(next);
       return next;
     }),

--- a/src/widgets/HiddenColumnsList.tsx
+++ b/src/widgets/HiddenColumnsList.tsx
@@ -1,0 +1,43 @@
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import {
+  IconButton,
+  List,
+  ListItem,
+  ListItemSecondaryAction,
+  ListItemText,
+  Stack,
+  Typography,
+} from '@mui/material';
+
+import { useBoardStore } from '@/store/board/store';
+import { useTodoPrefsStore } from '@/store/todoPrefsStore';
+
+export function HiddenColumnsList() {
+  const columns = useBoardStore(state => state.columns);
+  const hiddenIds = useTodoPrefsStore(state => state.hiddenColumnIds);
+  const toggleHidden = useTodoPrefsStore(state => state.toggleHiddenColumn);
+
+  const hiddenColumns = columns.filter(
+    c => !c.trashed && hiddenIds.includes(c.id),
+  );
+
+  if (hiddenColumns.length === 0) return null;
+
+  return (
+    <Stack spacing={1}>
+      <Typography variant="h3">Hidden Columns</Typography>
+      <List dense disablePadding>
+        {hiddenColumns.map(col => (
+          <ListItem key={col.id} sx={{ pl: 0 }}>
+            <ListItemText primary={col.title} sx={{ color: col.color }} />
+            <ListItemSecondaryAction>
+              <IconButton edge="end" onClick={() => toggleHidden(col.id)}>
+                <VisibilityIcon fontSize="small" />
+              </IconButton>
+            </ListItemSecondaryAction>
+          </ListItem>
+        ))}
+      </List>
+    </Stack>
+  );
+}

--- a/src/widgets/TodoList/TodoColumn.tsx
+++ b/src/widgets/TodoList/TodoColumn.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import AddIcon from '@mui/icons-material/Add';
-import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import { alpha, Box, Chip, IconButton, Stack, Typography } from '@mui/material';
 
@@ -62,11 +61,6 @@ export function TodoColumn({
   onHideColumn,
 }: TodoColumnProps) {
   const [creatingId, setCreatingId] = useState<string | null>(null);
-  const [hideColumn, setHideColumn] = useState(false);
-
-  useEffect(() => {
-    console.log(creatingId);
-  }, [creatingId]);
 
   // const orderedTasks = tasks.sort((a, b) => a.position - b.position);
 
@@ -127,24 +121,14 @@ export function TodoColumn({
             <IconButton
               size="small"
               className="column-hide-btn"
-              onClick={() => {
-                if (onHideColumn) {
-                  onHideColumn();
-                } else {
-                  setHideColumn(!hideColumn);
-                }
-              }}
+              onClick={onHideColumn}
               sx={{
-                opacity: hideColumn ? 0.5 : 0.8,
-                color: hideColumn ? 'text.secondary' : column.color,
-                visibility: hideColumn ? 'visible' : 'hidden',
+                opacity: 0.8,
+                color: column.color,
+                visibility: 'hidden',
               }}
             >
-              {hideColumn ? (
-                <VisibilityOffIcon fontSize="small" sx={{ fontSize: '1rem' }} />
-              ) : (
-                <VisibilityIcon fontSize="small" sx={{ fontSize: '1rem' }} />
-              )}
+              <VisibilityOffIcon fontSize="small" sx={{ fontSize: '1rem' }} />
             </IconButton>
           </Stack>
 
@@ -164,8 +148,7 @@ export function TodoColumn({
       </Box>
 
       <Stack gap={1}>
-        {!hideColumn &&
-          tasks &&
+        {tasks &&
           tasks.map(task => (
             <TaskCard
               key={task.id}
@@ -179,7 +162,7 @@ export function TodoColumn({
             />
           ))}
 
-        {!creatingId && showAddTaskInput && column.id && !hideColumn && (
+        {!creatingId && showAddTaskInput && column.id && (
           <AddTaskInput
             taskProperties={{ plannedDate: new Date() }}
             columnProperties={column}

--- a/src/widgets/TodoList/index.tsx
+++ b/src/widgets/TodoList/index.tsx
@@ -51,11 +51,13 @@ export function TodoList({ showDate }: TodoListProps) {
   const [editingTask, setEditingTask] = useState<Task | null>(null);
 
   const hideDoneColumn = useTodoPrefsStore(state => state.hideDoneColumn);
-  const setHideDoneColumn = useTodoPrefsStore(state => state.setHideDoneColumn);
+  const hiddenColumnIds = useTodoPrefsStore(state => state.hiddenColumnIds);
+  const toggleHiddenColumn = useTodoPrefsStore(state => state.toggleHiddenColumn);
 
   const columnsToRender = columns.filter(c => {
     if (c.trashed) return false;
     if (hideDoneColumn && c.title === defaultColumns.done.title) return false;
+    if (hiddenColumnIds.includes(c.id)) return false;
     return true;
   });
   const boardIsEmpty = columnsToRender.length === 0;
@@ -264,8 +266,7 @@ export function TodoList({ showDate }: TodoListProps) {
 
   const renderColumn = (column: Column) => {
     const colTasks = tasks.filter(t => t.columnId === column.id);
-    const onHideColumn =
-      column.title === defaultColumns.done.title ? () => setHideDoneColumn(true) : undefined;
+    const onHideColumn = () => toggleHiddenColumn(column.id);
     return (
       <TodoColumn
         key={column.id}


### PR DESCRIPTION
## Summary
- store hidden column ids in todo prefs
- render only visible columns
- show hidden columns with unhide button under event list
- adjust TodoColumn hide behavior

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e41b854dc8329b358c980ce3e1f24