### PR TITLE
feat: improve calendar routing and event handling

### DIFF
--- a/src/app/calendar/[[...date]]/page.tsx
+++ b/src/app/calendar/[[...date]]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { Box, Tab, Tabs } from '@mui/material';
 import {
@@ -13,15 +13,27 @@ import {
   startOfWeek,
   startOfYear,
 } from 'date-fns';
+import { useRouter } from 'next/navigation';
 
 import { PageContentLayout } from '@/components/PageContentLayout';
 import { useEvents } from '@/hooks/useEvents';
 import { useEventStore } from '@/store/eventStore';
+import { parseDateFromSlug } from '@/utils/dateSlug';
 import { BigCalendar, CalendarViewType, YearView } from '@/widgets/EventCalendar';
 
-export default function CalendarPage() {
+interface CalendarPageProps {
+  params: { date?: string[] };
+}
+
+export default function CalendarPage({ params }: CalendarPageProps) {
   const [view, setView] = useState<CalendarViewType | 'year'>('month');
-  const [currentDate, setCurrentDate] = useState(new Date());
+  const initialDate = useMemo(() => parseDateFromSlug(params.date), [params.date]);
+  const [currentDate, setCurrentDate] = useState(initialDate);
+  const router = useRouter();
+
+  useEffect(() => {
+    setCurrentDate(initialDate);
+  }, [initialDate]);
 
   const { start, end } = useMemo(() => {
     switch (view) {
@@ -44,6 +56,18 @@ export default function CalendarPage() {
     setView(value as CalendarViewType | 'year');
   };
 
+  const navigateToDate = (date: Date) => {
+    setCurrentDate(date);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+
+    let path = `/calendar/${year}`;
+    if (view !== 'year') path += `/${month}`;
+    if (view === 'day') path += `/${day}`;
+    router.push(path);
+  };
+
   return (
     <PageContentLayout title="Calendar" description="Your events in one place">
       <Tabs value={view} onChange={handleViewChange} sx={{ mb: 2 }}>
@@ -53,14 +77,14 @@ export default function CalendarPage() {
         <Tab label="Year" value="year" />
       </Tabs>
       {view === 'year' ? (
-        <YearView date={currentDate} onChange={setCurrentDate} />
+        <YearView date={currentDate} onChange={navigateToDate} />
       ) : (
         <Box>
           <BigCalendar
             events={events}
             date={currentDate}
             view={view}
-            onNavigate={setCurrentDate}
+            onNavigate={navigateToDate}
             onViewChange={setView}
           />
         </Box>

--- a/src/services/event-mapper.ts
+++ b/src/services/event-mapper.ts
@@ -11,16 +11,24 @@ export function mapGoogleEventToEvent(
     const calendar = calendars.find(cal => cal.id === event.calendarId);
 
     // Parse start and end times
-    const startTime = event.start.dateTime || event.start.date;
-    const endTime = event.end.dateTime || event.end.date;
+  const startTime = event.start.dateTime || event.start.date;
+  const endTime = event.end.dateTime || event.end.date;
 
     if (!startTime || !endTime) {
       console.warn('Event missing start or end time:', event.id);
       return null;
     }
 
-    const start = new Date(startTime);
-    const end = new Date(endTime);
+  const isAllDay = Boolean(event.start.date) && Boolean(event.end.date);
+  const parseDate = (value: string) =>
+    isAllDay ? new Date(`${value}T00:00:00`) : new Date(value);
+
+  const start = parseDate(startTime);
+  const end = parseDate(endTime);
+  if (isAllDay) {
+    end.setDate(end.getDate() - 1);
+    end.setHours(23, 59, 59, 999);
+  }
 
     // Validate dates
     if (isNaN(start.getTime()) || isNaN(end.getTime())) {

--- a/src/utils/dateSlug.ts
+++ b/src/utils/dateSlug.ts
@@ -1,0 +1,15 @@
+export function parseDateFromSlug(slug?: string[]): Date {
+  const now = new Date();
+
+  if (!slug || slug.length === 0) return now;
+
+  const [yearStr, monthStr, dayStr] = slug;
+  const year = Number(yearStr);
+  const month = monthStr ? Number(monthStr) : NaN;
+  const day = dayStr ? Number(dayStr) : NaN;
+
+  if (isNaN(year)) return now;
+  if (!isNaN(day) && !isNaN(month)) return new Date(year, month - 1, day);
+  if (!isNaN(month)) return new Date(year, month - 1, 1);
+  return new Date(year, 0, 1);
+}

--- a/src/widgets/EventCalendar/BigCalendar.tsx
+++ b/src/widgets/EventCalendar/BigCalendar.tsx
@@ -6,7 +6,7 @@ import { dateFnsLocalizer } from 'react-big-calendar';
 import { format, getDay, parse, startOfWeek } from 'date-fns';
 import { enUS } from 'date-fns/locale';
 
-import { IEvent } from '@/types/IEvent';
+import type { IEvent } from '@/types/IEvent';
 
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 
@@ -36,6 +36,11 @@ export function BigCalendar({ events, date, view, onNavigate, onViewChange }: Bi
     title: ev.title,
   }));
 
+  const getEventStyle = (event: IEvent) => {
+    const backgroundColor = event.calendar?.color;
+    return backgroundColor ? { style: { backgroundColor } } : {};
+  };
+
   return (
     <Calendar
       localizer={localizer}
@@ -46,6 +51,7 @@ export function BigCalendar({ events, date, view, onNavigate, onViewChange }: Bi
       view={view}
       onNavigate={onNavigate}
       onView={v => onViewChange(v as CalendarViewType)}
+      eventPropGetter={getEventStyle}
       style={{ height: '70vh' }}
     />
   );


### PR DESCRIPTION
## Summary
- enable dynamic calendar routing via `[[...date]]`
- apply calendar colors in calendar view
- fix timezone display for all-day events
- parse date path segments reliably

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ee01a76d4832993edfd61997a65e9