### PR TITLE
fix: ensure unique identifiers for ics events

### DIFF
--- a/src/app/api/ics-calendar/route.ts
+++ b/src/app/api/ics-calendar/route.ts
@@ -48,7 +48,8 @@ function extractEvents(
         if (e < start) continue;
         if (s > end) break;
         events.push({
-          id: uid,
+          // Combine UID and start time to uniquely identify each occurrence
+          id: `${uid}_${s.toISOString()}`,
           start: s,
           end: e,
           title: item.summary || baseTitle,
@@ -66,7 +67,8 @@ function extractEvents(
       }
       if (e < start || s > end) continue;
       events.push({
-        id: uid,
+        // Non-recurring events also combine UID and start for stability
+        id: `${uid}_${s.toISOString()}`,
         start: s,
         end: e,
         title: baseTitle,


### PR DESCRIPTION
## Summary
- make event IDs unique when parsing ICS calendar events by appending the ISO start time

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687ef8180cac83298d177c6e775769ec