### PR TITLE
Improve navigation speed

### DIFF
--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -3,15 +3,24 @@
 import { useEffect, useState } from 'react';
 
 import { Stack } from '@mui/material';
+import dynamic from 'next/dynamic';
 
 import { EventAlert } from '@/components/alert/EventAlert';
 import { Clock } from '@/components/Clock';
 import { TodoList } from '@/components/column/TodoList';
 import { ChangeSnackbar } from '@/components/event/ChangeSnackbar';
-import { EventList } from '@/components/event/EventList';
+
+// Lazily load heavy components to speed up initial render
+const EventTimeline = dynamic(
+  () => import('@/components/timeline/EventTimeline').then(m => m.EventTimeline),
+  { ssr: false },
+);
+const EventList = dynamic(
+  () => import('@/components/event/EventList').then(m => m.EventList),
+  { ssr: false },
+);
 import { HiddenColumnsList } from '@/components/HiddenColumnsList';
 import { TodoProgress } from '@/components/Progress';
-import { EventTimeline } from '@/components/timeline/EventTimeline';
 import { UndoSnackbar } from '@/components/UndoSnackbar';
 import { useLocation } from '@/hooks/useLocation';
 import { useResponsiveness } from '@/hooks/useResponsiveness';

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -3,11 +3,23 @@
 import { useState } from 'react';
 
 import { Box, Stack, Tab, Tabs, TextField, Typography } from '@mui/material';
+import dynamic from 'next/dynamic';
 
 import { PageContentLayout } from '@/components/PageContentLayout';
-import { AddTaskFloatButton } from '@/components/task/AddTaskFloatButton';
-import { AddTaskInput } from '@/components/task/AddTaskInput';
-import { TaskCard } from '@/components/task/TaskCard';
+
+// Lazy loaded components reduce the initial bundle size
+const AddTaskFloatButton = dynamic(
+  () => import('@/components/task/AddTaskFloatButton').then(m => m.AddTaskFloatButton),
+  { ssr: false },
+);
+const AddTaskInput = dynamic(
+  () => import('@/components/task/AddTaskInput').then(m => m.AddTaskInput),
+  { ssr: false },
+);
+const TaskCard = dynamic(
+  () => import('@/components/task/TaskCard').then(m => m.TaskCard),
+  { ssr: false },
+);
 import { useResponsiveness } from '@/hooks/useResponsiveness';
 import { useTasks } from '@/hooks/useTasks';
 import { customColors } from '@/styles/colors';

--- a/src/navigation/BottomNav.tsx
+++ b/src/navigation/BottomNav.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect } from 'react';
+
 import { BottomNavigation, BottomNavigationAction, Paper } from '@mui/material';
 import { usePathname, useRouter } from 'next/navigation';
 
@@ -18,6 +20,13 @@ export function BottomNav() {
   const routesToRender = [...routes.primary, ...routes.secondary].filter(
     route => route.showOnMobile,
   );
+
+  // Prefetch target routes for snappier navigation
+  useEffect(() => {
+    routesToRender.forEach(route => {
+      router.prefetch(route.href).catch(() => {});
+    });
+  }, [router, routesToRender]);
 
   return (
     <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }} elevation={3}>


### PR DESCRIPTION
## Summary
- load heavy board components lazily
- load task-related components lazily
- prefetch navigation routes for fast switching

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f138418508329b0d546f56f9ff74f