### PR TITLE
Automate tasks from calendar events

### DIFF
--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -25,6 +25,7 @@ import { useEvents } from '@/hooks/useEvents';
 import { useLocation } from '@/hooks/useLocation';
 import { useResponsiveness } from '@/hooks/useResponsiveness';
 import { useWeather } from '@/hooks/useWeather';
+import { processEventsColumn } from '@/services/eventsColumnService';
 import { useAudioStore } from '@/store/audioStore';
 import { useEventStore } from '@/store/eventStore';
 
@@ -34,6 +35,11 @@ export default function BoardPage() {
   const events = useEventStore(state => state.events);
   // Fetch events when visiting the board so data is available without opening the account page
   useEvents();
+
+  // create tasks from all-day events once per day
+  useEffect(() => {
+    void processEventsColumn();
+  }, [events]);
 
   const setAlertAcknowledged = useEventStore(state => state.setAlertAcknowledged);
   const isMeetingAlertEnabled = useAudioStore(state => state.meetingAlertEnabled);

--- a/src/config/defaultColumns.ts
+++ b/src/config/defaultColumns.ts
@@ -13,4 +13,8 @@ export const defaultColumns = {
     title: 'Draft',
     color: customColors.red.value,
   },
+  events: {
+    title: 'Events',
+    color: customColors.orange.value,
+  },
 };

--- a/src/hooks/useDefaultColumns.ts
+++ b/src/hooks/useDefaultColumns.ts
@@ -65,9 +65,29 @@ export function useDefaultColumns(columnKey: ColumnKey) {
     return todoCol;
   };
 
+  const initializeEventsColumn = async () => {
+    let eventsCol = allColumns.find(c => c.title === defaultColumns.events.title);
+
+    if (!eventsCol) {
+      await addColumn({
+        title: defaultColumns.events.title,
+        color: defaultColumns.events.color,
+        updatedAt: new Date(),
+      });
+      eventsCol = allColumns.find(c => c.title === defaultColumns.events.title);
+    }
+
+    if (eventsCol && eventsCol.trashed) {
+      await updateColumn({ id: eventsCol.id, trashed: false, updatedAt: new Date() });
+    }
+
+    return eventsCol;
+  };
+
   if (columnKey === 'draft') return initializeDraftColumn();
   if (columnKey === 'done') return initializeDoneColumn();
   if (columnKey === 'todo') return initializeTodoColumn();
+  if (columnKey === 'events') return initializeEventsColumn();
 
   if (Object.keys(defaultColumns).includes(columnKey)) {
     throw new Error(`Column ${columnKey} is not implemented in useDefaultColumns`);

--- a/src/services/eventsColumnService.ts
+++ b/src/services/eventsColumnService.ts
@@ -1,0 +1,92 @@
+import { defaultColumns } from '@/config/defaultColumns';
+import { useBoardStore } from '@/store/board/store';
+import { useEventStore } from '@/store/eventStore';
+import type { Column } from '@/types/column';
+import type { Event } from '@/types/Event';
+import { buildStorageKey } from '@/utils/localStorageUtils';
+import { RESET_TIME } from '@/utils/resetTime';
+import { isSameDay } from '@/utils/timeUtils';
+
+const STORAGE_KEY = buildStorageKey('events-column-last-run');
+
+function loadLastRun(): Date | null {
+  if (typeof window === 'undefined') return null;
+  const data = localStorage.getItem(STORAGE_KEY);
+  return data ? new Date(data) : null;
+}
+
+function saveLastRun(date: Date): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, date.toISOString());
+}
+
+function afterResetTime(now: Date): boolean {
+  const [h, m] = RESET_TIME.split(':').map(Number);
+  const reset = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    h,
+    m,
+    0,
+    0,
+  );
+  return now.getTime() >= reset.getTime();
+}
+
+function filterTodaysAllDayEvents(events: Event[], today: Date): Event[] {
+  return events.filter(evt => {
+    if (!evt.allDay) return false;
+    const start = new Date(evt.start);
+    return start.toDateString() === today.toDateString();
+  });
+}
+
+export async function processEventsColumn(now: Date = new Date()): Promise<void> {
+  const lastRun = loadLastRun();
+  if (lastRun && isSameDay(lastRun, now)) return;
+  if (!afterResetTime(now)) return;
+
+  const events = useEventStore.getState().events;
+  if (!Array.isArray(events) || events.length === 0) return;
+
+  const col = await ensureEventsColumn();
+  if (!col) return;
+
+  const todaysEvents = filterTodaysAllDayEvents(events, now);
+  const addTask = useBoardStore.getState().addTask;
+
+  for (const event of todaysEvents) {
+    await addTask({
+      title: event.title,
+      notes: event.description ?? '',
+      plannedDate: now,
+      columnId: col.id,
+      updatedAt: now,
+    });
+  }
+
+  saveLastRun(now);
+}
+
+async function ensureEventsColumn(): Promise<Column | null> {
+  const columns = useBoardStore.getState().columns;
+  const existing = columns.find(c => c.title === defaultColumns.events.title);
+  const addColumn = useBoardStore.getState().addColumn;
+  const updateColumn = useBoardStore.getState().updateColumn;
+
+  if (existing) {
+    if (existing.trashed) {
+      await updateColumn({ id: existing.id, trashed: false, updatedAt: new Date() });
+    }
+    return existing;
+  }
+
+  await addColumn({
+    title: defaultColumns.events.title,
+    color: defaultColumns.events.color,
+    updatedAt: new Date(),
+  });
+
+  return useBoardStore.getState().columns.find(c => c.title === defaultColumns.events.title) ?? null;
+}


### PR DESCRIPTION
## Summary
- add `Events` to default column config
- support `events` column in `useDefaultColumns`
- create `eventsColumnService` to convert all-day events into tasks once per day
- trigger event task processing from the board page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f2056199c83298fa08432c3a7caf7