### PR TITLE
feat: resizable event list width

### DIFF
--- a/src/store/eventListPrefsStore.ts
+++ b/src/store/eventListPrefsStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+
+import { getStoredFilters, setStoredFilters } from '@/utils/localStorageUtils';
+
+interface EventListPrefsState {
+  width: number;
+  setWidth: (width: number) => void;
+}
+
+type EventListPrefsData = Pick<EventListPrefsState, 'width'>;
+
+const STORAGE_KEY = 'event-list-prefs';
+
+function loadPrefs(): EventListPrefsData {
+  try {
+    return getStoredFilters<EventListPrefsData>(STORAGE_KEY) ?? { width: 250 };
+  } catch {
+    return { width: 250 };
+  }
+}
+
+function persistPrefs(state: EventListPrefsState) {
+  const data: EventListPrefsData = { width: state.width };
+  setStoredFilters(STORAGE_KEY, data);
+}
+
+export const useEventListPrefsStore = create<EventListPrefsState>(set => ({
+  ...loadPrefs(),
+  setWidth: width =>
+    set(state => {
+      const next = { ...state, width };
+      persistPrefs(next);
+      return next;
+    }),
+}));


### PR DESCRIPTION
## Summary
- add `eventListPrefsStore` to persist settings
- make `EventList` column resizable and persist width

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f2081d9e8832982d70dad77c6831f