### PR TITLE
feat: enhance task selection mode

### DIFF
--- a/src/components/TaskSelectionToolbar.tsx
+++ b/src/components/TaskSelectionToolbar.tsx
@@ -1,0 +1,59 @@
+import { Button, Paper, Stack, Typography, useTheme } from '@mui/material';
+
+interface TaskSelectionToolbarProps {
+  selectedCount: number;
+  onSelectAll: () => void;
+  onSetToday: () => void;
+  onClearDate: () => void;
+  onMarkNone: () => void;
+  onCancel: () => void;
+}
+
+export function TaskSelectionToolbar({
+  selectedCount,
+  onSelectAll,
+  onSetToday,
+  onClearDate,
+  onMarkNone,
+  onCancel,
+}: TaskSelectionToolbarProps) {
+  const theme = useTheme();
+
+  return (
+    <Paper
+      elevation={3}
+      sx={{
+        position: 'sticky',
+        bottom: 0,
+        p: 2,
+        borderTop: 1,
+        borderColor: 'divider',
+        backgroundColor: theme.palette.background.paper,
+        zIndex: theme.zIndex.appBar,
+      }}
+    >
+      <Stack direction="row" justifyContent="space-between" alignItems="center" flexWrap="wrap" gap={1}>
+        <Typography variant="body2" sx={{ ml: 1 }}>
+          {`${selectedCount} selected`}
+        </Typography>
+        <Stack direction="row" gap={1} flexWrap="wrap">
+          <Button onClick={onSelectAll} size="small" variant="outlined">
+            Select All
+          </Button>
+          <Button onClick={onSetToday} size="small" variant="contained">
+            Set to Today
+          </Button>
+          <Button onClick={onClearDate} size="small" variant="contained">
+            Clear Date
+          </Button>
+          <Button onClick={onMarkNone} size="small" variant="contained">
+            Mark as Not Important & Not Urgent
+          </Button>
+          <Button onClick={onCancel} size="small" variant="outlined">
+            Cancel
+          </Button>
+        </Stack>
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/components/task/TaskCard.styles.ts
+++ b/src/components/task/TaskCard.styles.ts
@@ -10,6 +10,7 @@ export const Container = styled(Box, {
   borderRadius: theme.shape.borderRadius,
   position: 'relative',
   backgroundColor: alpha(color, selected ? 0.25 : 0.15),
+  border: selected ? `2px solid ${theme.palette.primary.main}` : 'none',
   touchAction: 'none',
   cursor: 'grab',
   '&:hover .action-group': { visibility: 'visible' },

--- a/src/components/task/TaskCard.tsx
+++ b/src/components/task/TaskCard.tsx
@@ -90,6 +90,12 @@ export function TaskCard({
   const inputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setDragging] = useState(false);
 
+  const toggleSelected = useCallback(() => {
+    if (selectable) {
+      onSelectChange?.(task.id, !selected);
+    }
+  }, [onSelectChange, selectable, selected, task.id]);
+
   // sync edit mode if parent toggles it
   useEffect(() => {
     setIsEditing(editTask);
@@ -267,6 +273,7 @@ export function TaskCard({
         gap={itemsGap}
         paddingX={isMobile ? 2 : 1.5}
         paddingY={1.5}
+        onClick={toggleSelected}
         sx={{ cursor: isDragging ? 'grabbing' : undefined }}
         selected={selected}
         {...props}
@@ -275,6 +282,7 @@ export function TaskCard({
           <Checkbox
             size="small"
             checked={selected}
+            onClick={e => e.stopPropagation()}
             onChange={e => onSelectChange?.(task.id, e.target.checked)}
             inputProps={{ 'aria-label': 'Select task' }}
             sx={{ p: 0 }}
@@ -309,7 +317,7 @@ export function TaskCard({
                 )}
 
                 <S.TitleText
-                  onClick={() => setEditModalOpen(true)}
+                  onClick={selectable ? toggleSelected : () => setEditModalOpen(true)}
                   done={done}
                   untitled={!task.title}
                   textVariantSize={isMobile ? 'body1' : 'body2'}

--- a/src/hooks/useTaskSelection.ts
+++ b/src/hooks/useTaskSelection.ts
@@ -21,6 +21,10 @@ export function useTaskSelection() {
     });
   };
 
+  const selectAll = (ids: string[]) => {
+    setSelectedIds(new Set(ids));
+  };
+
   const clearSelection = () => setSelectedIds(new Set());
 
   const selectedCount = selectedIds.size;
@@ -31,6 +35,7 @@ export function useTaskSelection() {
     selectedCount,
     toggleSelecting,
     selectTask,
+    selectAll,
     clearSelection,
   };
 }


### PR DESCRIPTION
## Summary
- extend task selection hook with bulk select support
- add sticky toolbar for bulk task actions
- make TaskCard fully clickable in selection mode
- show visual indicator for selected TaskCard
- add bulk action handlers in matrix page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880b211702083298c37f1753ca995fb