### PR TITLE
feat: dynamic schedule view and range-based events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@tanstack/query-sync-storage-persister": "^5.80.7",
         "@tanstack/react-query": "^5.80.7",
         "@tanstack/react-query-persist-client": "^5.80.7",
+        "@tanstack/react-virtual": "^3.13.12",
         "axios": "^1.10.0",
         "babel-plugin-react-compiler": "^19.1.0-rc.2",
         "date-fns": "^4.1.0",
@@ -34,6 +35,8 @@
         "react-dom": "^19.0.0",
         "react-sounds": "^1.0.25",
         "react-text-to-speech": "^2.1.0",
+        "react-virtualized-auto-sizer": "^1.0.26",
+        "react-window": "^1.8.11",
         "zustand": "^5.0.5"
       },
       "devDependencies": {
@@ -1824,6 +1827,33 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.83.0",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -5107,6 +5137,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5893,6 +5929,33 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
+      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@tanstack/query-sync-storage-persister": "^5.80.7",
     "@tanstack/react-query": "^5.80.7",
     "@tanstack/react-query-persist-client": "^5.80.7",
+    "@tanstack/react-virtual": "^3.13.12",
     "axios": "^1.10.0",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
     "date-fns": "^4.1.0",
@@ -59,6 +60,8 @@
     "react-dom": "^19.0.0",
     "react-sounds": "^1.0.25",
     "react-text-to-speech": "^2.1.0",
+    "react-virtualized-auto-sizer": "^1.0.26",
+    "react-window": "^1.8.11",
     "zustand": "^5.0.5"
   },
   "devDependencies": {

--- a/src/components/calendar/CalendarViewContainer.tsx
+++ b/src/components/calendar/CalendarViewContainer.tsx
@@ -4,6 +4,7 @@ import { Box } from '@mui/material';
 
 import type { CalendarView } from '@/app/calendar/[[...date]]/page';
 import { useEvents } from '@/hooks/useEvents';
+import { endOfDay, monthRange, startOfDay, weekRange } from '@/utils/dateRange';
 import { DayView } from '@/views/DayView';
 import { MonthView } from '@/views/MonthView';
 import { ScheduleView } from '@/views/ScheduleView';
@@ -25,7 +26,31 @@ export function CalendarViewContainer({
   onViewChange,
   onNavigate,
 }: CalendarViewContainerProps) {
-  useEvents();
+  let rangeStart: Date | undefined;
+  let rangeEnd: Date | undefined;
+
+  switch (currentView) {
+    case 'day':
+      rangeStart = startOfDay(currentDate);
+      rangeEnd = endOfDay(currentDate);
+      break;
+    case 'week': {
+      const range = weekRange(currentDate);
+      rangeStart = range.start;
+      rangeEnd = range.end;
+      break;
+    }
+    case 'month': {
+      const range = monthRange(currentDate);
+      rangeStart = range.start;
+      rangeEnd = range.end;
+      break;
+    }
+    default:
+      break;
+  }
+
+  const { isLoading } = useEvents(rangeStart, rangeEnd);
 
   const commonProps = {
     currentDate,
@@ -35,7 +60,12 @@ export function CalendarViewContainer({
   };
 
   return (
-    <Box sx={{ height: '100%', overflow: 'auto' }}>
+    <Box sx={{ height: '100%', overflow: 'auto', position: 'relative' }}>
+      {isLoading && (
+        <Box sx={{ position: 'absolute', top: 0, left: 0, right: 0 }}>
+          <Box sx={{ height: 2, bgcolor: 'primary.main', opacity: 0.3 }} />
+        </Box>
+      )}
       {currentView === 'day' && <DayView {...commonProps} />}
       {currentView === 'week' && <WeekView {...commonProps} />}
       {currentView === 'month' && <MonthView {...commonProps} />}

--- a/src/components/calendar/ScheduleDay.tsx
+++ b/src/components/calendar/ScheduleDay.tsx
@@ -1,0 +1,72 @@
+import { Box, Divider, Typography, useTheme } from '@mui/material';
+
+import { EventCard } from '@/components/calendar/EventCard';
+import { Event } from '@/types/Event';
+
+interface ScheduleDayProps {
+  date: Date;
+  events: Event[];
+  onSelect: (event: Event) => void;
+}
+
+export function ScheduleDay({ date, events, onSelect }: ScheduleDayProps) {
+  const theme = useTheme();
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const dayOnly = new Date(date);
+  dayOnly.setHours(0, 0, 0, 0);
+
+  const heading = dayOnly.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: today.getFullYear() === dayOnly.getFullYear() ? undefined : 'numeric',
+  });
+
+  const relative = (() => {
+    const diff = (dayOnly.getTime() - today.getTime()) / (1000 * 60 * 60 * 24);
+    if (diff === 0) return 'Today';
+    if (diff === 1) return 'Tomorrow';
+    if (diff === -1) return 'Yesterday';
+    if (diff > 1 && diff < 7) return `In ${diff} days`;
+    if (diff < -1 && diff > -7) return `${Math.abs(diff)} days ago`;
+    return '';
+  })();
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          p: 2,
+          backgroundColor: theme.palette.grey[50],
+          borderBottom: 1,
+          borderColor: 'divider',
+          position: 'sticky',
+          top: 0,
+          zIndex: 1,
+        }}
+      >
+        <Typography variant="h6" sx={{ fontWeight: 600 }}>
+          {heading}
+        </Typography>
+        {relative && (
+          <Typography variant="caption" color="text.secondary">
+            {relative}
+          </Typography>
+        )}
+      </Box>
+
+      {events.map(event => (
+        <EventCard key={event.id} event={event} compact onClick={() => onSelect(event)} />
+      ))}
+
+      {events.length === 0 && (
+        <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+          No events
+        </Typography>
+      )}
+
+      <Divider sx={{ my: 1 }} />
+    </Box>
+  );
+}

--- a/src/utils/dateRange.ts
+++ b/src/utils/dateRange.ts
@@ -1,0 +1,29 @@
+export function startOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function endOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(23, 59, 59, 999);
+  return d;
+}
+
+export function weekRange(date: Date): { start: Date; end: Date } {
+  const start = startOfDay(new Date(date));
+  start.setDate(start.getDate() - start.getDay());
+  const end = endOfDay(new Date(start));
+  end.setDate(start.getDate() + 6);
+  return { start, end };
+}
+
+export function monthRange(date: Date): { start: Date; end: Date } {
+  const first = new Date(date.getFullYear(), date.getMonth(), 1);
+  const start = startOfDay(first);
+  start.setDate(start.getDate() - start.getDay());
+  const last = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+  const end = endOfDay(last);
+  end.setDate(end.getDate() + (6 - end.getDay()));
+  return { start, end };
+}

--- a/src/views/ScheduleView.tsx
+++ b/src/views/ScheduleView.tsx
@@ -1,22 +1,16 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import AutoSizer from 'react-virtualized-auto-sizer';
 
-import {
-  Box,
-  Button,
-  ButtonGroup,
-  Chip,
-  Divider,
-  List,
-  ListItem,
-  ListItemText,
-  Typography,
-  useTheme,
-} from '@mui/material';
+import { Box, CircularProgress } from '@mui/material';
+import { useVirtualizer } from '@tanstack/react-virtual';
 
+import { ScheduleDay } from '@/components/calendar/ScheduleDay';
+import { useEvents } from '@/hooks/useEvents';
 import { useEventStore } from '@/store/eventStore';
 import { Event } from '@/types/Event';
+import { endOfDay, startOfDay } from '@/utils/dateRange';
 
 interface ScheduleViewProps {
   currentDate: Date;
@@ -25,262 +19,87 @@ interface ScheduleViewProps {
   onNavigate: (date: Date, view: 'day' | 'week' | 'month' | 'year' | 'schedule') => void;
 }
 
-type ScheduleFilter = 'upcoming' | 'today' | 'week' | 'month';
-
 export function ScheduleView({ onNavigate }: ScheduleViewProps) {
-  const theme = useTheme();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [rangeStart, setRangeStart] = useState(() => startOfDay(new Date()));
+  const [rangeEnd, setRangeEnd] = useState(() => endOfDay(new Date()));
+
+  const { isLoading } = useEvents(rangeStart, rangeEnd);
   const events = useEventStore(state => state.events);
-  const [filter, setFilter] = useState<ScheduleFilter>('upcoming');
 
-  const now = new Date();
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const tomorrow = new Date(today);
-  tomorrow.setDate(today.getDate() + 1);
-  const nextWeek = new Date(today);
-  nextWeek.setDate(today.getDate() + 7);
-  const nextMonth = new Date(today);
-  nextMonth.setMonth(today.getMonth() + 1);
+  const [days, setDays] = useState<Date[]>([]);
 
-  const getFilteredEvents = () => {
-    const sortedEvents = [...events].sort(
-      (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
-    );
-
-    switch (filter) {
-      case 'today':
-        return sortedEvents.filter(event => {
-          const eventDate = new Date(event.start);
-          return eventDate >= today && eventDate < tomorrow;
-        });
-      case 'week':
-        return sortedEvents.filter(event => {
-          const eventDate = new Date(event.start);
-          return eventDate >= today && eventDate < nextWeek;
-        });
-      case 'month':
-        return sortedEvents.filter(event => {
-          const eventDate = new Date(event.start);
-          return eventDate >= today && eventDate < nextMonth;
-        });
-      case 'upcoming':
-      default:
-        return sortedEvents.filter(event => {
-          const eventDate = new Date(event.start);
-          return eventDate >= now;
-        });
+  useEffect(() => {
+    const list: Date[] = [];
+    const cur = new Date(rangeStart);
+    while (cur <= rangeEnd) {
+      list.push(new Date(cur));
+      cur.setDate(cur.getDate() + 1);
     }
-  };
+    setDays(list);
+  }, [rangeStart, rangeEnd]);
 
-  const filteredEvents = getFilteredEvents();
-
-  const groupEventsByDate = (events: typeof filteredEvents) => {
-    const groups: { [key: string]: typeof events } = {};
-
-    events.forEach(event => {
-      const eventDate = new Date(event.start);
-      const dateKey = eventDate.toDateString();
-
-      if (!groups[dateKey]) {
-        groups[dateKey] = [];
-      }
-      groups[dateKey].push(event);
+  const loadPrevDay = useCallback(() => {
+    setRangeStart(prev => {
+      const next = new Date(prev);
+      next.setDate(next.getDate() - 1);
+      return startOfDay(next);
     });
+  }, []);
 
-    return groups;
-  };
-
-  const eventGroups = groupEventsByDate(filteredEvents);
-
-  const formatDateHeader = (dateString: string) => {
-    const date = new Date(dateString);
-    const isToday = date.toDateString() === today.toDateString();
-    const isTomorrow = date.toDateString() === tomorrow.toDateString();
-
-    if (isToday) return 'Today';
-    if (isTomorrow) return 'Tomorrow';
-
-    return date.toLocaleDateString('en-US', {
-      weekday: 'long',
-      month: 'long',
-      day: 'numeric',
-      year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
+  const loadNextDay = useCallback(() => {
+    setRangeEnd(prev => {
+      const next = new Date(prev);
+      next.setDate(next.getDate() + 1);
+      return endOfDay(next);
     });
-  };
+  }, []);
 
-  const getRelativeTime = (date: Date) => {
-    const diffMs = date.getTime() - now.getTime();
-    const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+  const rowVirtualizer = useVirtualizer({
+    count: days.length,
+    getScrollElement: () => containerRef.current,
+    estimateSize: () => 250,
+    overscan: 2,
+  });
 
-    if (diffDays === 0) return 'Today';
-    if (diffDays === 1) return 'Tomorrow';
-    if (diffDays < 7) return `In ${diffDays} days`;
-    if (diffDays < 30) return `In ${Math.ceil(diffDays / 7)} weeks`;
-    return `In ${Math.ceil(diffDays / 30)} months`;
-  };
+  useEffect(() => {
+    const items = rowVirtualizer.getVirtualItems();
+    const first = items[0];
+    if (first && first.index < 2) loadPrevDay();
+    const last = items[items.length - 1];
+    if (last && last.index > days.length - 3) loadNextDay();
+  }, [rowVirtualizer, days.length, loadPrevDay, loadNextDay]);
 
   const handleEventClick = (event: Event) => {
-    const eventDate = new Date(event.start);
-    onNavigate(eventDate, 'day');
+    const date = new Date(event.start);
+    onNavigate(date, 'day');
   };
 
+  const grouped = (date: Date) =>
+    events.filter(e => startOfDay(e.start).getTime() === startOfDay(date).getTime());
+
   return (
-    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      {/* Filter buttons */}
-      <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>
-        <ButtonGroup size="small" variant="outlined" fullWidth>
-          <Button
-            onClick={() => setFilter('today')}
-            variant={filter === 'today' ? 'contained' : 'outlined'}
-          >
-            Today
-          </Button>
-          <Button
-            onClick={() => setFilter('week')}
-            variant={filter === 'week' ? 'contained' : 'outlined'}
-          >
-            This Week
-          </Button>
-          <Button
-            onClick={() => setFilter('month')}
-            variant={filter === 'month' ? 'contained' : 'outlined'}
-          >
-            This Month
-          </Button>
-          <Button
-            onClick={() => setFilter('upcoming')}
-            variant={filter === 'upcoming' ? 'contained' : 'outlined'}
-          >
-            Upcoming
-          </Button>
-        </ButtonGroup>
-      </Box>
-
-      {/* Events list */}
-      <Box sx={{ flex: 1, overflow: 'auto' }}>
-        {Object.keys(eventGroups).length === 0 ? (
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              height: '100%',
-              p: 4,
-            }}
-          >
-            <Typography variant="h6" color="text.secondary" gutterBottom>
-              No events found
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {filter === 'today' && 'No events scheduled for today'}
-              {filter === 'week' && 'No events scheduled for this week'}
-              {filter === 'month' && 'No events scheduled for this month'}
-              {filter === 'upcoming' && 'No upcoming events'}
-            </Typography>
-          </Box>
-        ) : (
-          <List sx={{ p: 0 }}>
-            {Object.entries(eventGroups).map(([dateString, dayEvents], index) => (
-              <Box key={dateString}>
-                {/* Date header */}
-                <Box
-                  sx={{
-                    p: 2,
-                    backgroundColor: theme.palette.grey[50],
-                    borderBottom: 1,
-                    borderColor: 'divider',
-                    position: 'sticky',
-                    top: 0,
-                    zIndex: 1,
-                  }}
-                >
-                  <Typography variant="h6" sx={{ fontWeight: 600 }}>
-                    {formatDateHeader(dateString)}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {getRelativeTime(new Date(dateString))}
-                  </Typography>
-                </Box>
-
-                {/* Events for this date */}
-                {dayEvents.map(event => (
-                  <ListItem
-                    key={event.id}
-                    sx={{
-                      py: 1,
-                      px: 2,
-                      cursor: 'pointer',
-                      '&:hover': {
-                        backgroundColor: theme.palette.action.hover,
-                      },
-                    }}
-                    onClick={() => handleEventClick(event)}
-                  >
-                    <ListItemText
-                      primary={
-                        <>
-                          <Typography variant="subtitle1" sx={{ fontWeight: 500 }}>
-                            {event.title}
-                          </Typography>
-                          {event.allDay && (
-                            <Chip
-                              label="All day"
-                              size="small"
-                              variant="outlined"
-                              sx={{ fontSize: '0.7rem', height: 20 }}
-                            />
-                          )}
-                        </>
-                      }
-                      secondary={
-                        <>
-                          {!event.allDay && (
-                            <Typography variant="body2" color="text.secondary">
-                              {new Date(event.start).toLocaleTimeString('en-US', {
-                                hour: 'numeric',
-                                minute: '2-digit',
-                                hour12: true,
-                              })}
-                              {event.end && (
-                                <>
-                                  {' - '}
-                                  {new Date(event.end).toLocaleTimeString('en-US', {
-                                    hour: 'numeric',
-                                    minute: '2-digit',
-                                    hour12: true,
-                                  })}
-                                </>
-                              )}
-                            </Typography>
-                          )}
-                          {event.description && (
-                            <Typography
-                              variant="body2"
-                              color="text.secondary"
-                              sx={{
-                                mt: 0.5,
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                display: '-webkit-box',
-                                WebkitLineClamp: 2,
-                                WebkitBoxOrient: 'vertical',
-                              }}
-                            >
-                              {event.description}
-                            </Typography>
-                          )}
-                        </>
-                      }
-                    />
-                  </ListItem>
-                ))}
-
-                {index < Object.keys(eventGroups).length - 1 && <Divider sx={{ my: 1 }} />}
+    <Box ref={containerRef} sx={{ height: '100%', overflow: 'auto' }}>
+      <AutoSizer disableWidth>{({ height }) => (
+        <Box sx={{ height }}>
+          <Box style={{ height: rowVirtualizer.getTotalSize(), position: 'relative' }}>
+            {rowVirtualizer.getVirtualItems().map(item => (
+              <Box
+                key={item.key}
+                ref={rowVirtualizer.measureElement}
+                style={{ position: 'absolute', top: 0, left: 0, width: '100%', transform: `translateY(${item.start}px)` }}
+              >
+                <ScheduleDay date={days[item.index]} events={grouped(days[item.index])} onSelect={handleEventClick} />
               </Box>
             ))}
-          </List>
-        )}
-      </Box>
+            {isLoading && (
+              <Box sx={{ p: 2, display: 'flex', justifyContent: 'center' }}>
+                <CircularProgress size={20} />
+              </Box>
+            )}
+          </Box>
+        </Box>
+      )}</AutoSizer>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- implement date range utilities
- query events per visible range in `CalendarViewContainer`
- add new `ScheduleDay` for scroll feed items
- rewrite `ScheduleView` with infinite scrolling and virtualization
- include `@tanstack/react-virtual` for performant lists

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880c4ff40108329831f3093ddb3c49e