### PR TITLE
feat: add daily load indicator

### DIFF
--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -18,6 +18,7 @@ const EventTimeline = dynamic(
 const EventList = dynamic(() => import('@/components/event/EventList').then(m => m.EventList), {
   ssr: false,
 });
+import { DailyTimeLoadIndicator } from '@/components/DailyTimeLoadIndicator';
 import { HiddenColumnsList } from '@/components/HiddenColumnsList';
 import { TodoProgress } from '@/components/Progress';
 import { UndoSnackbar } from '@/components/UndoSnackbar';
@@ -80,7 +81,10 @@ export default function BoardPage() {
 
         <Stack alignItems="flex-start">
           <Stack spacing={2}>
-            <TodoProgress alignSelf="flex-end" />
+            <Stack direction="row" gap={1} alignSelf="flex-end" alignItems="center">
+              <DailyTimeLoadIndicator />
+              <TodoProgress />
+            </Stack>
             <EventList events={events} key={`${now.toISOString()}-EventList`} />
             <HiddenColumnsList />
           </Stack>

--- a/src/components/DailyTimeLoadIndicator.tsx
+++ b/src/components/DailyTimeLoadIndicator.tsx
@@ -1,0 +1,57 @@
+import { Box, Stack, Tooltip, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+
+import { useBoardStore } from '@/store/board/store';
+import { useEventStore } from '@/store/eventStore';
+import { filterNonFullDayEvents, filterTodayEvents } from '@/utils/eventUtils';
+import { formatDuration, isSameDay } from '@/utils/timeUtils';
+
+export function DailyTimeLoadIndicator() {
+  const tasks = useBoardStore(state => state.tasks);
+  const events = useEventStore(state => state.events);
+  const { palette } = useTheme();
+
+  const today = new Date();
+
+  // Sum estimated time of tasks planned for today
+  const taskMinutes = tasks
+    .filter(t => !t.trashed && isSameDay(t.plannedDate, today))
+    .reduce((total, task) => total + (task.estimatedTime ?? 0), 0);
+
+  // Filter and sum durations of non all-day events happening today
+  const todaysEvents = filterTodayEvents(filterNonFullDayEvents(events ?? []), today);
+  const eventMinutes = todaysEvents.reduce((total, event) => {
+    const start = new Date(event.start).getTime();
+    const end = new Date(event.end).getTime();
+    const minutes = Math.max(0, Math.round((end - start) / 60000));
+    return total + minutes;
+  }, 0);
+
+  const totalMinutes = taskMinutes + eventMinutes;
+  const formatted = formatDuration(totalMinutes);
+
+  // choose color based on total planned time
+  let color: string = 'success.main';
+  if (totalMinutes > 8 * 60) color = 'grey.800';
+  else if (totalMinutes > 6 * 60) color = 'error.main';
+  else if (totalMinutes > 4 * 60) color = 'warning.main';
+
+  return (
+    <Tooltip title="Includes all planned tasks and timed events for today">
+      <Box
+        sx={{
+          border: `1px solid ${palette.divider}`,
+          borderRadius: 1,
+          px: 1,
+          py: 0.5,
+        }}
+      >
+        <Stack direction="row" spacing={0.5} alignItems="center">
+          <Typography variant="body2" color={color}>
+            {`\u{1F552} ${formatted} planned today`}
+          </Typography>
+        </Stack>
+      </Box>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## Summary
- show total planned time for tasks and events
- place Daily Time Load indicator next to progress bar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68819759542c8329a76be9ddc62fb271