### PR TITLE
feat: add Cloudinary image manager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,9 @@ NEXT_PUBLIC_SUPABASE_URL=your-supabase-project-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-public-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-optional-service-role-key
 
+# Cloudinary
 NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=your-cloudinary-cloud-name
+CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=
+

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,14 @@ const nextConfig: NextConfig = {
   experimental: {
     reactCompiler: true,
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+      },
+    ],
+  },
   env: {
     NEXT_PUBLIC_APP_VERSION: process.env.VERCEL_GIT_COMMIT_SHA || packageJson.version,
     NEXT_PUBLIC_APP_BUILD_DATE: new Date().toISOString(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@tanstack/react-query-persist-client": "^5.80.7",
         "axios": "^1.10.0",
         "babel-plugin-react-compiler": "^19.1.0-rc.2",
+        "cloudinary": "^2.7.0",
         "date-fns": "^4.1.0",
         "dompurify": "^3.2.6",
         "howler": "^2.2.4",
@@ -3045,6 +3046,19 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cloudinary": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.7.0.tgz",
+      "integrity": "sha512-qrqDn31+qkMCzKu1GfRpzPNAO86jchcNwEHCUiqvPHNSFqu7FTNF9FuAkBUyvM1CFFgFPu64NT0DyeREwLwK0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=9"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -5300,6 +5314,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6091,6 +6111,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@tanstack/react-query-persist-client": "^5.80.7",
     "axios": "^1.10.0",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
+    "cloudinary": "^2.7.0",
     "date-fns": "^4.1.0",
     "dompurify": "^3.2.6",
     "howler": "^2.2.4",

--- a/src/app/api/images/list/route.ts
+++ b/src/app/api/images/list/route.ts
@@ -1,0 +1,36 @@
+import { v2 as cloudinary } from 'cloudinary';
+import { NextResponse } from 'next/server';
+
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
+
+interface CloudinaryResource {
+  secure_url: string;
+  public_id: string;
+}
+
+export async function GET() {
+  try {
+    const result = (await cloudinary.api.resources({
+      type: 'upload',
+      resource_type: 'image',
+      max_results: 100,
+    })) as { resources: CloudinaryResource[] };
+
+    const images = result.resources.map(resource => ({
+      url: resource.secure_url,
+      publicId: resource.public_id,
+    }));
+
+    return NextResponse.json({ images });
+  } catch (error) {
+    console.error('Cloudinary list failed', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch images' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/images/upload/route.ts
+++ b/src/app/api/images/upload/route.ts
@@ -1,0 +1,36 @@
+import { v2 as cloudinary } from 'cloudinary';
+import { NextRequest, NextResponse } from 'next/server';
+
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get('file');
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+    }
+
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    const uploadResult = await cloudinary.uploader.upload(
+      `data:${file.type};base64,${buffer.toString('base64')}`,
+    );
+
+    return NextResponse.json({
+      url: uploadResult.secure_url,
+      publicId: uploadResult.public_id,
+    });
+  } catch (error) {
+    console.error('Cloudinary upload failed', error);
+    return NextResponse.json(
+      { error: 'Failed to upload image' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/images/page.tsx
+++ b/src/app/images/page.tsx
@@ -1,0 +1,19 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+import { CloudinaryImageManager } from '@/features/image/components/CloudinaryImageManager';
+
+export default function ImagesPage() {
+  function handleSelect(url: string) {
+    console.log('Selected image:', url);
+  }
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h4" sx={{ mb: 2 }}>
+        Images
+      </Typography>
+      <CloudinaryImageManager onSelect={handleSelect} />
+    </Box>
+  );
+}

--- a/src/features/image/api/imageApi.ts
+++ b/src/features/image/api/imageApi.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+import type { CloudinaryImage } from '@/features/image/types/CloudinaryImage';
+
+export async function listImages(): Promise<CloudinaryImage[]> {
+  const response = await axios.get('/api/images/list');
+  return response.data.images as CloudinaryImage[];
+}
+
+export async function uploadImage(file: File): Promise<CloudinaryImage> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const response = await axios.post('/api/images/upload', formData);
+  return response.data as CloudinaryImage;
+}

--- a/src/features/image/components/CloudinaryImageManager.tsx
+++ b/src/features/image/components/CloudinaryImageManager.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useState } from 'react';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import ImageList from '@mui/material/ImageList';
+import ImageListItem from '@mui/material/ImageListItem';
+import { useTheme } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import Image from 'next/image';
+
+import { listImages, uploadImage } from '@/features/image/api/imageApi';
+import type { CloudinaryImage } from '@/features/image/types/CloudinaryImage';
+
+interface CloudinaryImageManagerProps {
+  onSelect: (imageUrl: string) => void;
+}
+
+export function CloudinaryImageManager({ onSelect }: CloudinaryImageManagerProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [selected, setSelected] = useState<CloudinaryImage | null>(null);
+  const queryClient = useQueryClient();
+  const theme = useTheme();
+  const downSm = useMediaQuery(theme.breakpoints.down('sm'));
+  const downMd = useMediaQuery(theme.breakpoints.down('md'));
+  const cols = downSm ? 2 : downMd ? 3 : 4;
+
+  const imagesQuery = useQuery({
+    queryKey: ['cloudinary-images'],
+    queryFn: listImages,
+  });
+
+  const uploadMutation = useMutation({
+    mutationFn: uploadImage,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cloudinary-images'] });
+      setFile(null);
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
+      setPreview(null);
+    },
+  });
+
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const chosenFile = event.target.files?.[0];
+    if (chosenFile) {
+      setFile(chosenFile);
+      setPreview(URL.createObjectURL(chosenFile));
+    }
+  }
+
+  function handleDrop(event: React.DragEvent<HTMLDivElement>) {
+    event.preventDefault();
+    const droppedFile = event.dataTransfer.files?.[0];
+    if (droppedFile) {
+      setFile(droppedFile);
+      setPreview(URL.createObjectURL(droppedFile));
+    }
+  }
+
+  function handleUpload() {
+    if (file) {
+      uploadMutation.mutate(file);
+    }
+  }
+
+  function confirmSelection() {
+    if (selected) {
+      onSelect(selected.url);
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
+    };
+  }, [preview]);
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          border: '1px dashed',
+          borderColor: 'divider',
+          borderRadius: 1,
+          p: 2,
+          mb: 2,
+          textAlign: 'center',
+        }}
+        onDragOver={event => event.preventDefault()}
+        onDrop={handleDrop}
+      >
+        <input
+          id="image-upload-input"
+          type="file"
+          accept="image/*"
+          style={{ display: 'none' }}
+          onChange={handleFileChange}
+        />
+        {preview ? (
+          <Box sx={{ mb: 2, display: 'flex', justifyContent: 'center' }}>
+            <Image
+              src={preview}
+              alt="Preview"
+              width={200}
+              height={200}
+              style={{ objectFit: 'cover' }}
+            />
+          </Box>
+        ) : null}
+        <label htmlFor="image-upload-input">
+          <Button variant="contained" component="span" disabled={uploadMutation.isPending}>
+            Choose File
+          </Button>
+        </label>
+        <Button
+          variant="outlined"
+          sx={{ ml: 2 }}
+          onClick={handleUpload}
+          disabled={!file || uploadMutation.isPending}
+        >
+          Upload
+        </Button>
+        {uploadMutation.isPending && <CircularProgress size={24} sx={{ ml: 2 }} />}
+        {uploadMutation.isError && (
+          <Typography color="error" sx={{ mt: 1 }}>
+            Failed to upload image.
+          </Typography>
+        )}
+      </Box>
+
+      {imagesQuery.isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : imagesQuery.isError ? (
+        <Alert severity="error">Failed to load images.</Alert>
+      ) : (
+        <ImageList cols={cols} gap={8} sx={{ m: 0 }}>
+          {imagesQuery.data?.map(image => (
+            <ImageListItem
+              key={image.publicId}
+              onClick={() => setSelected(image)}
+              sx={{
+                cursor: 'pointer',
+                border: selected?.publicId === image.publicId ? '2px solid' : 'none',
+                borderColor: 'primary.main',
+              }}
+            >
+              <Image
+                src={image.url}
+                alt={image.publicId}
+                width={200}
+                height={200}
+                loading="lazy"
+                style={{ objectFit: 'cover' }}
+              />
+            </ImageListItem>
+          ))}
+        </ImageList>
+      )}
+
+      <Box sx={{ textAlign: 'right', mt: 2 }}>
+        <Button variant="contained" onClick={confirmSelection} disabled={!selected}>
+          Select Image
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/src/features/image/types/CloudinaryImage.ts
+++ b/src/features/image/types/CloudinaryImage.ts
@@ -1,0 +1,4 @@
+export interface CloudinaryImage {
+  url: string;
+  publicId: string;
+}


### PR DESCRIPTION
## Summary
- add Next.js API routes for Cloudinary image upload and listing
- implement CloudinaryImageManager component and images page
- configure Cloudinary env variables and remote image support

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689253b96c6c8329893baf630a11ef5d