### PR TITLE
feat: add type-safe file handling for maps

### DIFF
--- a/src/features/file/components/FileGallery.tsx
+++ b/src/features/file/components/FileGallery.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
@@ -8,6 +9,7 @@ import CardMedia from '@mui/material/CardMedia';
 import Pagination from '@mui/material/Pagination';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import Image from 'next/image';
 
 import type { File } from '@/features/file/types/File';
@@ -64,27 +66,42 @@ export function FileGallery({
         }}
         gap={2}
       >
-        {paged.map(img => (
+        {paged.map(f => (
           <Card
-            key={img.publicId}
-            elevation={selected?.publicId === img.publicId ? 4 : 1}
+            key={f.publicId}
+            elevation={selected?.publicId === f.publicId ? 4 : 1}
             sx={{
-              border: selected?.publicId === img.publicId ? '2px solid' : 'none',
+              border: selected?.publicId === f.publicId ? '2px solid' : 'none',
               borderColor: 'primary.main',
             }}
           >
-            <CardActionArea onClick={() => onSelect(img)}>
+            <CardActionArea onClick={() => onSelect(f)}>
               <CardMedia
-                component={() => (
-                  <Image
-                    src={img.url}
-                    alt={img.publicId}
-                    width={200}
-                    height={200}
-                    style={{ objectFit: 'cover' }}
-                    loading="lazy"
-                  />
-                )}
+                component={() => {
+                  if (f.resourceType === 'image') {
+                    return (
+                      <Image
+                        src={f.url}
+                        alt={f.publicId}
+                        width={200}
+                        height={200}
+                        style={{ objectFit: 'cover' }}
+                        loading="lazy"
+                      />
+                    );
+                  }
+                  if (f.resourceType === 'video') {
+                    return <video src={f.url} controls style={{ width: '100%' }} />;
+                  }
+                  return (
+                    <Stack alignItems="center" p={2}>
+                      <InsertDriveFileIcon />
+                      <Typography variant="body2" mt={1}>
+                        {f.publicId}
+                      </Typography>
+                    </Stack>
+                  );
+                }}
               />
             </CardActionArea>
           </Card>

--- a/src/features/file/components/FileUploadArea.tsx
+++ b/src/features/file/components/FileUploadArea.tsx
@@ -2,11 +2,14 @@
 
 import { ChangeEvent, DragEvent } from 'react';
 
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import Image from 'next/image';
+
+import type { File as AppFile } from '@/features/file/types/File';
 
 interface FileUploadAreaProps {
   file: File | null;
@@ -15,7 +18,8 @@ interface FileUploadAreaProps {
   error: boolean;
   onFileChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onDrop: (e: DragEvent<HTMLDivElement>) => void;
-  onUpload: () => void;
+  onUpload: () => Promise<AppFile>;
+  onSaveToSupabase?: (file: AppFile) => void | Promise<void>;
 }
 
 export function FileUploadArea({
@@ -26,7 +30,33 @@ export function FileUploadArea({
   onFileChange,
   onDrop,
   onUpload,
+  onSaveToSupabase,
 }: FileUploadAreaProps) {
+  const handleUpload = async () => {
+    const uploaded = await onUpload();
+    if (onSaveToSupabase) {
+      await onSaveToSupabase(uploaded);
+    }
+  };
+
+  const renderPreview = () => {
+    if (!file || !preview) return null;
+    if (file.type.startsWith('image/')) {
+      return (
+        <Image src={preview} alt="Preview" width={200} height={200} style={{ objectFit: 'cover' }} />
+      );
+    }
+    if (file.type.startsWith('video/')) {
+      return <video src={preview} controls style={{ maxWidth: 200 }} />;
+    }
+    return (
+      <Box display="flex" flexDirection="column" alignItems="center" gap={1}>
+        <InsertDriveFileIcon />
+        <Typography variant="body2">{file.name}</Typography>
+      </Box>
+    );
+  };
+
   return (
     <Box
       onDragOver={e => e.preventDefault()}
@@ -41,35 +71,28 @@ export function FileUploadArea({
       }}
     >
       <input
-        id="image-upload-input"
+        id="file-upload-input"
         type="file"
-        accept="image/*"
-        style={{ display: 'none' }}
         onChange={onFileChange}
+        style={{ display: 'none' }}
       />
       {preview && (
         <Box mb={2} display="flex" justifyContent="center">
-          <Image
-            src={preview}
-            alt="Preview"
-            width={200}
-            height={200}
-            style={{ objectFit: 'cover' }}
-          />
+          {renderPreview()}
         </Box>
       )}
-      <label htmlFor="image-upload-input">
+      <label htmlFor="file-upload-input">
         <Button variant="contained" component="span" disabled={loading}>
           Choose file
         </Button>
       </label>
-      <Button variant="outlined" sx={{ ml: 2 }} onClick={onUpload} disabled={!file || loading}>
+      <Button variant="outlined" sx={{ ml: 2 }} onClick={handleUpload} disabled={!file || loading}>
         Upload
       </Button>
       {loading && <CircularProgress size={24} sx={{ ml: 2 }} />}
       {error && (
         <Typography color="error" mt={1}>
-          Failed to upload image
+          Failed to upload file
         </Typography>
       )}
     </Box>

--- a/src/features/file/hooks/useFile.ts
+++ b/src/features/file/hooks/useFile.ts
@@ -41,3 +41,16 @@ export function useUploadFile() {
     },
   });
 }
+
+type SaveFileVariables = { file: File };
+
+export function useSaveFile() {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, SaveFileVariables>({
+    mutationFn: ({ file }) => fileService.add(file),
+    onSuccess: () => {
+      // Update any components relying on the files query
+      queryClient.invalidateQueries({ queryKey: ['files'] });
+    },
+  });
+}

--- a/src/features/file/services/fileService.ts
+++ b/src/features/file/services/fileService.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 
+import { useFilesStore } from '@/features/file/store/useFilesStore';
 import type { File } from '@/features/file/types/File';
 
 export interface FileListResponse {
@@ -40,5 +41,15 @@ export const fileService = {
       headers: { 'Content-Type': 'multipart/form-data' },
     });
     return data;
+  },
+
+  add: async (file: File): Promise<void> => {
+    // Persist file metadata in Supabase via the files store
+    await useFilesStore.getState().add({
+      url: file.url,
+      publicId: file.publicId,
+      resourceType: file.resourceType,
+      createdAt: file.createdAt,
+    });
   },
 };

--- a/src/features/map/components/MapCard.tsx
+++ b/src/features/map/components/MapCard.tsx
@@ -1,16 +1,38 @@
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 import { Card, CardActionArea, CardContent, Stack, Typography } from '@mui/material';
 import Link from 'next/link';
 
+import type { File } from '@/features/file/types/File';
 import type { MapRecord } from '@/features/map/types/MapRecord';
 
 interface MapCardProps {
   map: MapRecord;
+  file?: File;
 }
 
-export function MapCard({ map }: MapCardProps) {
+export function MapCard({ map, file }: MapCardProps) {
+  const renderPreview = () => {
+    if (file?.resourceType === 'video') {
+      return <video src={map.fileUrl} style={{ width: '100%' }} />;
+    }
+    if (file?.resourceType === 'image') {
+      // eslint-disable-next-line @next/next/no-img-element
+      return <img src={map.fileUrl} alt={map.name} style={{ width: '100%' }} />;
+    }
+    return (
+      <Stack alignItems="center" py={2}>
+        <InsertDriveFileIcon />
+        <Typography variant="body2" mt={1}>
+          {map.filePublicId}
+        </Typography>
+      </Stack>
+    );
+  };
+
   return (
     <Card variant="outlined" sx={{ width: 300 }}>
       <CardActionArea component={Link} href={`/maps/${map.id}`} sx={{ height: '100%' }}>
+        {renderPreview()}
         <CardContent>
           <Stack gap={1}>
             <Typography variant="h6" noWrap>

--- a/src/features/map/components/MapCreateDialog.tsx
+++ b/src/features/map/components/MapCreateDialog.tsx
@@ -14,10 +14,8 @@ import {
 } from '@mui/material';
 
 import { FileUploadArea } from '@/features/file/components/FileUploadArea';
-import { File } from '@/features/file/types/File';
-import { uploadImage } from '@/features/image/api/imageApi';
-import { useCloudinaryImagesStore } from '@/features/image/store/useCloudinaryImagesStore';
-import { uploadMapFile } from '@/features/map/api/mapApi';
+import { useSaveFile, useUploadFile } from '@/features/file/hooks/useFile';
+import type { File as AppFile } from '@/features/file/types/File';
 import { useMapsStore } from '@/features/map/store/useMapsStore';
 import type { MapRecord } from '@/features/map/types/MapRecord';
 
@@ -28,14 +26,15 @@ interface MapCreateDialogProps {
 
 export function MapCreateDialog({ open, onClose }: MapCreateDialogProps) {
   const addMap = useMapsStore(s => s.add);
-  const addCloudImage = useCloudinaryImagesStore(s => s.add);
+  const uploadMutation = useUploadFile();
+  const saveFileMutation = useSaveFile();
 
   const [name, setName] = useState('');
   const [file, setFile] = useState<File | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
+  const [resourceType, setResourceType] = useState<AppFile['resourceType']>('image');
+  const [uploadedFile, setUploadedFile] = useState<AppFile | null>(null);
   const [geoJson, setGeoJson] = useState<GeoJSON.FeatureCollection | null>(null);
-  const [cloudImage, setCloudImage] = useState<File | null>(null);
-  const [uploading, setUploading] = useState(false);
   const [error, setError] = useState(false);
 
   useEffect(() => {
@@ -44,8 +43,7 @@ export function MapCreateDialog({ open, onClose }: MapCreateDialogProps) {
       setFile(null);
       setPreview(null);
       setGeoJson(null);
-      setCloudImage(null);
-      setUploading(false);
+      setUploadedFile(null);
       setError(false);
     }
     return () => {
@@ -58,7 +56,6 @@ export function MapCreateDialog({ open, onClose }: MapCreateDialogProps) {
     if (!f) return;
     setFile(f);
     if (f.type.includes('json') || f.name.endsWith('.geojson')) {
-      // GeoJSON file
       const reader = new FileReader();
       reader.onload = ev => {
         try {
@@ -69,8 +66,15 @@ export function MapCreateDialog({ open, onClose }: MapCreateDialogProps) {
         }
       };
       reader.readAsText(f);
+      setPreview(null);
+      setResourceType('raw');
     } else {
       setPreview(URL.createObjectURL(f));
+      if (f.type.startsWith('video/')) {
+        setResourceType('video');
+      } else {
+        setResourceType('image');
+      }
     }
   };
 
@@ -83,45 +87,34 @@ export function MapCreateDialog({ open, onClose }: MapCreateDialogProps) {
     }
   };
 
-  const handleUploadImage = async () => {
-    if (!file) return;
-    setUploading(true);
-    try {
-      const result = await uploadImage(file);
-      setCloudImage(result);
-      addCloudImage({ ...result, createdAt: new Date() });
-      setError(false);
-    } catch {
-      setError(true);
-    } finally {
-      setUploading(false);
-    }
+  const handleUpload = async (): Promise<AppFile> => {
+    if (!file) throw new Error('No file selected');
+    const result = await uploadMutation.mutateAsync({ file, resourceType });
+    setUploadedFile(result.file);
+    setError(false);
+    return result.file;
   };
 
   const handleSave = async () => {
-    if (!file || !name) return;
-    setUploading(true);
-    try {
-      const fileUrl = await uploadMapFile(file);
-      const newMap: Omit<MapRecord, 'id' | 'trashed' | 'updatedAt' | 'isSynced'> = {
-        name,
-        fileUrl,
-        geoJson: geoJson || undefined,
-        regionColors: {},
-        regionLabels: {},
-        regionTooltips: {},
-        createdAt: new Date(),
-      };
-      addMap(newMap as MapRecord);
-      onClose();
-    } catch {
-      setError(true);
-    } finally {
-      setUploading(false);
+    if (!uploadedFile || !name) return;
+    const newMap: Omit<MapRecord, 'id' | 'trashed' | 'updatedAt' | 'isSynced'> = {
+      name,
+      filePublicId: uploadedFile.publicId,
+      fileUrl: uploadedFile.url,
+      geoJson: geoJson || undefined,
+      regionColors: {},
+      regionLabels: {},
+      regionTooltips: {},
+      createdAt: new Date(),
+    };
+    addMap(newMap as MapRecord);
+    if (resourceType === 'image' || resourceType === 'video') {
+      await saveFileMutation.mutateAsync({ file: uploadedFile });
     }
+    onClose();
   };
 
-  const isImage = !!preview;
+  const hasPreview = Boolean(preview);
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="mobileSm">
@@ -134,15 +127,15 @@ export function MapCreateDialog({ open, onClose }: MapCreateDialogProps) {
             onChange={e => setName(e.target.value)}
             fullWidth
           />
-          {isImage ? (
+          {hasPreview ? (
             <FileUploadArea
               file={file}
               preview={preview}
-              loading={uploading}
-              error={error}
+              loading={uploadMutation.isPending}
+              error={uploadMutation.isError || error}
               onFileChange={handleFileChange}
               onDrop={handleDrop}
-              onUpload={handleUploadImage}
+              onUpload={handleUpload}
             />
           ) : (
             <Stack>
@@ -160,7 +153,7 @@ export function MapCreateDialog({ open, onClose }: MapCreateDialogProps) {
         <Button onClick={onClose}>Cancel</Button>
         <Button
           onClick={handleSave}
-          disabled={!name || !file || (isImage && !cloudImage) || uploading}
+          disabled={!name || !uploadedFile || uploadMutation.isPending}
           variant="contained"
         >
           Save

--- a/src/features/map/types/MapRecord.ts
+++ b/src/features/map/types/MapRecord.ts
@@ -13,4 +13,5 @@ export interface MapRecord extends BaseType, MapMetadata {
   name: string;
   filePublicId: string; // Cloudinary public ID
   fileUrl: string; // secure_url from Cloudinary
+  geoJson?: GeoJSON.FeatureCollection;
 }

--- a/src/features/map/views/MapEditorView.tsx
+++ b/src/features/map/views/MapEditorView.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from 'react';
 
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 import { Button, Drawer, Stack, TextField, Typography } from '@mui/material';
 
 import { PageSection } from '@/core/components/PageSection';
+import { useFilesStore } from '@/features/file/store/useFilesStore';
 import { useMapsStore } from '@/features/map/store/useMapsStore';
 import type { MapRecord } from '@/features/map/types/MapRecord';
 import { ColorPicker } from '@/shared/components/ColorPicker';
@@ -68,6 +70,7 @@ function buildPaths(geo: GeoJSON.FeatureCollection, width: number, height: numbe
 export function MapEditorView({ mapId }: MapEditorViewProps) {
   const map: MapRecord | undefined = useMapsStore(s => s.items.find(m => m.id === mapId));
   const updateMap = useMapsStore(s => s.update);
+  const files = useFilesStore(s => s.items);
 
   const [selected, setSelected] = useState<string | null>(null);
   const [color, setColor] = useState('');
@@ -97,6 +100,8 @@ export function MapEditorView({ mapId }: MapEditorViewProps) {
     setSelected(null);
   };
 
+  const file = files.find(f => f.publicId === map?.filePublicId);
+
   if (!map) {
     return (
       <PageSection title="Map">
@@ -123,8 +128,19 @@ export function MapEditorView({ mapId }: MapEditorViewProps) {
         </Stack>
       ) : (
         <Stack alignItems="center">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={map.fileUrl} alt={map.name} style={{ maxWidth: '100%' }} />
+          {file?.resourceType === 'video' && (
+            <video src={map.fileUrl} controls style={{ maxWidth: '100%' }} />
+          )}
+          {file?.resourceType === 'image' && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={map.fileUrl} alt={map.name} style={{ maxWidth: '100%' }} />
+          )}
+          {(!file || file.resourceType === 'raw') && (
+            <Stack alignItems="center" gap={1}>
+              <InsertDriveFileIcon />
+              <Typography variant="body2">{map.filePublicId}</Typography>
+            </Stack>
+          )}
         </Stack>
       )}
       <Drawer anchor="right" open={Boolean(selected)} onClose={() => setSelected(null)}>

--- a/src/features/map/views/MapsView.tsx
+++ b/src/features/map/views/MapsView.tsx
@@ -6,12 +6,14 @@ import AddIcon from '@mui/icons-material/Add';
 import { Button, Stack, Typography } from '@mui/material';
 
 import { PageSection } from '@/core/components/PageSection';
+import { useFilesStore } from '@/features/file/store/useFilesStore';
 import { MapCard } from '@/features/map/components/MapCard';
 import { MapCreateDialog } from '@/features/map/components/MapCreateDialog';
 import { useMapsStore } from '@/features/map/store/useMapsStore';
 
 export function MapsView() {
   const maps = useMapsStore(s => s.items);
+  const files = useFilesStore(s => s.items);
   const [open, setOpen] = useState(false);
 
   return (
@@ -28,9 +30,10 @@ export function MapsView() {
       {maps.length === 0 && <Typography>No maps yet. Click “New Map” to create one.</Typography>}
 
       <Stack direction="row" flexWrap="wrap" gap={2}>
-        {maps.map(m => (
-          <MapCard key={m.id} map={m} />
-        ))}
+        {maps.map(m => {
+          const file = files.find(f => f.publicId === m.filePublicId);
+          return <MapCard key={m.id} map={m} file={file} />;
+        })}
       </Stack>
 
       <MapCreateDialog open={open} onClose={() => setOpen(false)} />


### PR DESCRIPTION
## Summary
- persist Cloudinary files to Supabase when reused
- render files based on resource type across file and map features
- enable map creation with conditional file saving and previews

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892b9b090fc8329aa3fd4f3b5bd6daa